### PR TITLE
Replace `Partitioning` with explicit `Segment` model and restructure the encoding pipeline

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -45,4 +45,5 @@ AI agents alike. Agent-agnostic by design.
 | Changing the feature file schema       | `decisions/feature-files.md`, `modules/encoding.md` |
 | Editing encoding / regression logic    | `modules/encoding.md`                               |
 | Consuming fMRIPrep outputs             | `external/fmriprep.md`                              |
-| Introducing a new partition entity     | `decisions/semantic-entity.md`, `external/bids.md`  |
+| Introducing a new segment entity       | `decisions/semantic-entity.md`, `external/bids.md`  |
+| Changing segment metadata convention   | `decisions/segment-metadata.md`, `modules/encoding.md` |

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -18,33 +18,37 @@ Feature I/O is implemented in `hypline/features/utils.py` (formerly `hypline/fea
 
 ## Naming
 
-Feature files inherit **stimulus-side identity entities** from the source
-BOLD (`sub`, `ses`, `task`, `run`), plus any semantic entities that define
-the time window (e.g. the partition entity inferred from events.tsv), plus
-hypline's own `feature` entity:
+Feature files carry **stimulus-side identity entities** from the source BOLD (`sub`, `ses`,
+`task`, `run`), the segment entity value (e.g. `trial-1`), and hypline's own `feature` entity:
 
 ```
-sub-01_ses-01_task-movie_run-1_block-1_feature-clip.parquet
+sub-01_ses-01_task-movie_run-1_trial-1_feature-clip.parquet
 ```
 
-Feature files must be provided at the partition entity granularity. Additional descriptive
-entities are allowed (e.g. `condition`, `trial`) — see [semantic-entity.md](semantic-entity.md).
+Feature files carry only structural identity — descriptive attributes (condition, stimulus
+item, etc.) live in `events.json` under `Segments` and are joined at enrichment time. Do not
+put descriptive entities on feature filenames; they belong in the sidecar.
 
-Feature files do **not** carry acquisition entities (`acq`, `ce`, `rec`,
-`dir`). Features are stimulus-derived — the same stimulus embedding applies
-regardless of scanner acquisition parameters. Encoding validation enforces
-this: if BOLD files carry acquisition variants, feature files are not
-required to mirror them.
+Feature files do **not** carry acquisition entities (`acq`, `ce`, `rec`, `dir`). Features are
+stimulus-derived — the same stimulus embedding applies regardless of scanner acquisition
+parameters. Encoding validation enforces this: if BOLD files carry acquisition variants,
+feature files are not required to mirror them.
+
+## Conflict rule (filename entity vs. events.json metadata)
+
+If a metadata key from `events.json` `Segments` already appears on the feature filename with
+the same value, the match is allowed (redundant but harmless). If the values differ, the
+pipeline raises — two sources of truth disagree. This supports migration: existing feature
+files carrying descriptive entities do not need immediate renaming if the sidecar agrees.
 
 ## Mirroring requirement
 
-Feature filenames must carry the same stimulus-side identity entities as
-their source BOLD file. If BOLD has `ses-01_run-1`, the feature file must
-too.
+Feature filenames must carry the same stimulus-side identity entities as their source BOLD
+file. If BOLD has `ses-01_run-1`, the feature file must too.
 
-This is how pipelines match features to BOLD runs. Aggregating features
-across sessions or runs (e.g. a subject-level embedding) is out of scope
-for encoding models — such features don't map 1:1 to BOLD TRs.
+This is how pipelines match features to BOLD runs. Aggregating features across sessions or
+runs (e.g. a subject-level embedding) is out of scope for encoding models — such features
+don't map 1:1 to BOLD TRs.
 
 ## Temporal alignment
 

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -26,7 +26,7 @@ sub-01_ses-01_task-movie_run-1_trial-1_feature-clip.parquet
 ```
 
 Feature files carry only structural identity — descriptive attributes (condition, stimulus
-item, etc.) live in `events.json` under `Segments` and are joined at enrichment time. Do not
+item, etc.) live in `events.json` under `SegmentMetadata` and are joined at enrichment time. Do not
 put descriptive entities on feature filenames; they belong in the sidecar.
 
 Feature files do **not** carry acquisition entities (`acq`, `ce`, `rec`, `dir`). Features are
@@ -38,10 +38,10 @@ feature files are not required to mirror them.
 
 `events.json` is the authoritative source for descriptive metadata. Four cases:
 
-- Sidecar-only (key in `Segments`, absent from filename): merged onto the resolved `CellKey`.
+- Sidecar-only (key in `SegmentMetadata`, absent from filename): merged onto the resolved `CellKey`.
 - Both, same value: allowed; redundant but harmless.
 - Both, different value: raise — the two sources of truth disagree.
-- Filename-only descriptive (key absent from `Segments`): raise, pointing user to events.json.
+- Filename-only descriptive (key absent from `SegmentMetadata`): raise, pointing user to events.json.
 
 For unsegmented runs (no events.tsv key-value rows), only `ses` and `run` are valid on
 feature filenames — any other entity raises.

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -34,6 +34,22 @@ stimulus-derived — the same stimulus embedding applies regardless of scanner a
 parameters. Encoding validation enforces this: if BOLD files carry acquisition variants,
 feature files are not required to mirror them.
 
+## CellKey
+
+`CellKey` is the open-schema row key for a feature time window. After enrichment it carries:
+- Filename entities: `ses`, `run`, segment entity value (e.g. `trial=1`)
+- Metadata entities from `events.json` `SegmentMetadata` (e.g. `cond=R`, `item=101`)
+
+Excluded from `CellKey` (`CellKey.EXCLUDE`): `sub`, `task`, `acq`, `ce`, `rec`, `dir`
+(invariant within a training call), `desc`, `res`, `den`, `echo` (BOLD image-variant
+derivatives), `space`, `feature` (orthogonal axes). Entities are present or absent — no
+`None` sentinel. Equality and hashing are order-independent.
+
+CV splits are expressed by querying `CellKey` entities:
+```python
+train = [s for k, s in data.row_slices.items() if k["trial"] == "1"]
+```
+
 ## Filename entity vs. events.json metadata
 
 `events.json` is the authoritative source for descriptive metadata. Four cases:

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -34,12 +34,17 @@ stimulus-derived — the same stimulus embedding applies regardless of scanner a
 parameters. Encoding validation enforces this: if BOLD files carry acquisition variants,
 feature files are not required to mirror them.
 
-## Conflict rule (filename entity vs. events.json metadata)
+## Filename entity vs. events.json metadata
 
-If a metadata key from `events.json` `Segments` already appears on the feature filename with
-the same value, the match is allowed (redundant but harmless). If the values differ, the
-pipeline raises — two sources of truth disagree. This supports migration: existing feature
-files carrying descriptive entities do not need immediate renaming if the sidecar agrees.
+`events.json` is the authoritative source for descriptive metadata. Four cases:
+
+- Sidecar-only (key in `Segments`, absent from filename): merged onto the resolved `CellKey`.
+- Both, same value: allowed; redundant but harmless.
+- Both, different value: raise — the two sources of truth disagree.
+- Filename-only descriptive (key absent from `Segments`): raise, pointing user to events.json.
+
+For unsegmented runs (no events.tsv key-value rows), only `ses` and `run` are valid on
+feature filenames — any other entity raises.
 
 ## Mirroring requirement
 

--- a/notes/decisions/segment-metadata.md
+++ b/notes/decisions/segment-metadata.md
@@ -1,20 +1,20 @@
 # Segment metadata
 
-Design record for the `events.json` `Segments` field — per-segment descriptive entities
+Design record for the `events.json` `SegmentMetadata` field — per-segment descriptive entities
 used for filtering and CV splits.
 
 ## Purpose
 
 Feature filenames carry only structural identity: `ses`, `run`, and the segment entity value
 (e.g. `trial-1`). Descriptive attributes — condition, stimulus item, counterbalance group —
-live in `events.json` under the `Segments` key and are joined onto `CellKey` at enrichment
+live in `events.json` under the `SegmentMetadata` key and are joined onto `CellKey` at enrichment
 time.
 
 ## Wire format (events.json)
 
 ```json
 {
-  "Segments": [
+  "SegmentMetadata": [
     {"trial": "1", "cond": "R", "item": "101"},
     {"trial": "2", "cond": "L", "item": "102"},
     {"trial": "3", "cond": "R", "item": "103"}
@@ -22,14 +22,14 @@ time.
 }
 ```
 
-- `Segments` is a list of records; each record is a flat dict of BIDS entity key-value pairs.
+- `SegmentMetadata` is a list of records; each record is a flat dict of BIDS entity key-value pairs.
 - One key per record must match the run's segment entity (e.g. `"trial"`); its value is the
   bare segment value (e.g. `"1"`, not `"trial-1"`).
 - Remaining keys are metadata entities — must match `BIDS_ENTITY_KEY_RE` (`^[a-z]+$`).
 - Values must be strings matching `BIDS_ENTITY_VALUE_RE` (`^[a-zA-Z0-9]+$`). Non-string JSON
   types (numbers, bools) are rejected — BIDS values are strings on filenames, and metadata
   values become filename-shaped tokens after enrichment.
-- `Segments` is optional. Absence = no metadata for that run; `CellKey` carries filename
+- `SegmentMetadata` is optional. Absence = no metadata for that run; `CellKey` carries filename
   entities only.
 
 ## Validation
@@ -42,6 +42,19 @@ Within a single events.json (enforced in `bold.load_bold_meta`):
   `rec`, `dir`, `run`). Encoding-pipeline reserved keys (`space`, `feature`) are rejected
   later by `CellKey.EXCLUDE` during `_resolve_cell_keys` — keeping `bold.py` agnostic of
   encoding-pipeline concerns.
+
+## Single-segment runs
+
+A run with one segment row in events.tsv is **segmented** (segment count = 1), not unsegmented.
+Feature filenames must carry the segment entity (e.g. `block-1`), same as multi-segment runs.
+
+- **Unsegmented** = no events.tsv rows = use the entire BOLD run. Feature filenames carry `ses`/`run` only.
+- **Single-segment** = one events.tsv row = slice the run by that segment. Feature filenames must identify the segment.
+
+The distinction is whether a slice contract exists, not how many segments there are. Pre/post
+run padding (instructions, fixation, scanner ramp-up) is near-universal in practice, so the
+"whole-run-as-one-segment" case (onset=0, duration=full_run) is rare but permitted — declare
+one explicit row in events.tsv covering the full duration.
 
 Cross-run (enforced in `Encoding._discover_bold`):
 - All segmented runs share the same metadata key set. Strict — a segmented run with no
@@ -56,7 +69,7 @@ class Segment:
     entity: str           # e.g. "trial"
     value: str            # bare value, e.g. "1"
     slice: slice          # TR-slice derived from events.tsv onset/duration
-    metadata: dict[str, str]  # e.g. {"cond": "R", "item": "101"}; empty if no Segments
+    metadata: dict[str, str]  # e.g. {"cond": "R", "item": "101"}; empty if no SegmentMetadata
 
 class BoldMeta(NamedTuple):
     bids: BIDSPath
@@ -105,7 +118,7 @@ onset   duration  trial_type
 90.0    10.0      rest
 ```
 
-events.json Segments as above. BOLD TR=2.0s, 50 TRs total.
+events.json SegmentMetadata as above. BOLD TR=2.0s, 50 TRs total.
 
 Resulting BoldMeta.segments:
 ```python

--- a/notes/decisions/segment-metadata.md
+++ b/notes/decisions/segment-metadata.md
@@ -25,24 +25,28 @@ time.
 - `Segments` is a list of records; each record is a flat dict of BIDS entity key-value pairs.
 - One key per record must match the run's segment entity (e.g. `"trial"`); its value is the
   bare segment value (e.g. `"1"`, not `"trial-1"`).
-- Remaining keys are metadata entities — must match `^[a-z]+$` (valid BIDS entity names).
-- Values must match `^[a-zA-Z0-9]+$` (valid BIDS entity values).
+- Remaining keys are metadata entities — must match `BIDS_ENTITY_KEY_RE` (`^[a-z]+$`).
+- Values must be strings matching `BIDS_ENTITY_VALUE_RE` (`^[a-zA-Z0-9]+$`). Non-string JSON
+  types (numbers, bools) are rejected — BIDS values are strings on filenames, and metadata
+  values become filename-shaped tokens after enrichment.
 - `Segments` is optional. Absence = no metadata for that run; `CellKey` carries filename
   entities only.
 
-## Validation (enforced in `_discover_bold`)
+## Validation
 
-Within a single events.json:
+Within a single events.json (enforced in `bold.load_bold_meta`):
 - Every record has the segment-entity key.
 - Segment entity values match events.tsv key-value rows exactly (set equality).
 - All records have identical metadata key sets (schema invariance).
-- No metadata key collides with reserved entities (`sub`, `ses`, `run`, `task`, `space`,
-  `feature`).
+- No metadata key collides with BOLD identity entities (`sub`, `ses`, `task`, `acq`, `ce`,
+  `rec`, `dir`, `run`). Encoding-pipeline reserved keys (`space`, `feature`) are rejected
+  later by `CellKey.EXCLUDE` during `_enrich_cells` — keeping `bold.py` agnostic of
+  encoding-pipeline concerns.
 
-Cross-run (within a training call):
-- All non-empty runs share the same metadata key set. Runs with absent `events.json` have
-  empty metadata and pass through — the cross-run schema invariance is enforced later via
-  enriched-`CellKey`-schema invariance.
+Cross-run (enforced in `Encoding._discover_bold`):
+- All segmented runs share the same metadata key set. Strict — a segmented run with no
+  events.json (empty metadata) does not match a segmented run with populated metadata.
+  Mixing the two raises rather than silently routing partial metadata downstream.
 
 ## In-memory representation
 

--- a/notes/decisions/segment-metadata.md
+++ b/notes/decisions/segment-metadata.md
@@ -40,7 +40,7 @@ Within a single events.json (enforced in `bold.load_bold_meta`):
 - All records have identical metadata key sets (schema invariance).
 - No metadata key collides with BOLD identity entities (`sub`, `ses`, `task`, `acq`, `ce`,
   `rec`, `dir`, `run`). Encoding-pipeline reserved keys (`space`, `feature`) are rejected
-  later by `CellKey.EXCLUDE` during `_enrich_cells` — keeping `bold.py` agnostic of
+  later by `CellKey.EXCLUDE` during `_resolve_cell_keys` — keeping `bold.py` agnostic of
   encoding-pipeline concerns.
 
 Cross-run (enforced in `Encoding._discover_bold`):
@@ -59,7 +59,7 @@ class Segment:
     metadata: dict[str, str]  # e.g. {"cond": "R", "item": "101"}; empty if no Segments
 
 class BoldMeta(NamedTuple):
-    path: Path
+    bids: BIDSPath
     repetition_time: float
     segments: list[Segment]   # empty list if unsegmented run
 ```
@@ -67,7 +67,7 @@ class BoldMeta(NamedTuple):
 Slices use bare values as keys (matching `Segment.value`) — the segment entity name is
 available on `Segment.entity` and is not redundantly embedded in the value.
 
-## CellKey enrichment (`_enrich_cells`)
+## CellKey enrichment (`_resolve_cell_keys`)
 
 For each feature cell, `Segment.metadata` is merged into the cell's `CellKey`:
 
@@ -75,9 +75,18 @@ For each feature cell, `Segment.metadata` is merged into the cell's `CellKey`:
 enriched = CellKey(**{**dict(cell_key.items()), **segment.metadata})
 ```
 
-Conflict rule: if a metadata key already exists on the filename-derived `CellKey` with the
-same value, the match is allowed (redundant but harmless). If the values differ, raise —
-the two sources of truth disagree.
+Source-of-truth rule: events.json is authoritative for descriptive segment metadata. The
+feature filename carries only `ses`, `run`, and the segment entity. All other entities
+either belong to `CellKey.EXCLUDE` (invariant-across-training or image-variant entities,
+rejected at `CellKey` construction) or must come from events.json. Any descriptive entity
+on a feature filename that is absent from `seg.metadata` is rejected.
+
+Four filename × sidecar cases:
+- Sidecar-only (key in `seg.metadata`, absent from filename): merged onto enriched `CellKey`.
+- Both, same value: allowed; redundant but harmless.
+- Both, different value: raise — the two sources of truth disagree.
+- Filename-only descriptive (non-identity, non-segment, non-reserved key on filename, absent
+  from `seg.metadata`): raise, pointing user to events.json.
 
 After enrichment, all `bids_filters` (including metadata-entity filters like `cond-R`) apply
 uniformly against the enriched `CellKey`. No separate metadata-aware filter path needed.

--- a/notes/decisions/segment-metadata.md
+++ b/notes/decisions/segment-metadata.md
@@ -1,0 +1,109 @@
+# Segment metadata
+
+Design record for the `events.json` `Segments` field — per-segment descriptive entities
+used for filtering and CV splits.
+
+## Purpose
+
+Feature filenames carry only structural identity: `ses`, `run`, and the segment entity value
+(e.g. `trial-1`). Descriptive attributes — condition, stimulus item, counterbalance group —
+live in `events.json` under the `Segments` key and are joined onto `CellKey` at enrichment
+time.
+
+## Wire format (events.json)
+
+```json
+{
+  "Segments": [
+    {"trial": "1", "cond": "R", "item": "101"},
+    {"trial": "2", "cond": "L", "item": "102"},
+    {"trial": "3", "cond": "R", "item": "103"}
+  ]
+}
+```
+
+- `Segments` is a list of records; each record is a flat dict of BIDS entity key-value pairs.
+- One key per record must match the run's segment entity (e.g. `"trial"`); its value is the
+  bare segment value (e.g. `"1"`, not `"trial-1"`).
+- Remaining keys are metadata entities — must match `^[a-z]+$` (valid BIDS entity names).
+- Values must match `^[a-zA-Z0-9]+$` (valid BIDS entity values).
+- `Segments` is optional. Absence = no metadata for that run; `CellKey` carries filename
+  entities only.
+
+## Validation (enforced in `_discover_bold`)
+
+Within a single events.json:
+- Every record has the segment-entity key.
+- Segment entity values match events.tsv key-value rows exactly (set equality).
+- All records have identical metadata key sets (schema invariance).
+- No metadata key collides with reserved entities (`sub`, `ses`, `run`, `task`, `space`,
+  `feature`).
+
+Cross-run (within a training call):
+- All non-empty runs share the same metadata key set. Runs with absent `events.json` have
+  empty metadata and pass through — the cross-run schema invariance is enforced later via
+  enriched-`CellKey`-schema invariance.
+
+## In-memory representation
+
+```python
+@dataclass(frozen=True)
+class Segment:
+    entity: str           # e.g. "trial"
+    value: str            # bare value, e.g. "1"
+    slice: slice          # TR-slice derived from events.tsv onset/duration
+    metadata: dict[str, str]  # e.g. {"cond": "R", "item": "101"}; empty if no Segments
+
+class BoldMeta(NamedTuple):
+    path: Path
+    repetition_time: float
+    segments: list[Segment]   # empty list if unsegmented run
+```
+
+Slices use bare values as keys (matching `Segment.value`) — the segment entity name is
+available on `Segment.entity` and is not redundantly embedded in the value.
+
+## CellKey enrichment (`_enrich_cells`)
+
+For each feature cell, `Segment.metadata` is merged into the cell's `CellKey`:
+
+```python
+enriched = CellKey(**{**dict(cell_key.items()), **segment.metadata})
+```
+
+Conflict rule: if a metadata key already exists on the filename-derived `CellKey` with the
+same value, the match is allowed (redundant but harmless). If the values differ, raise —
+the two sources of truth disagree.
+
+After enrichment, all `bids_filters` (including metadata-entity filters like `cond-R`) apply
+uniformly against the enriched `CellKey`. No separate metadata-aware filter path needed.
+
+## Example — full picture
+
+events.tsv:
+```
+onset   duration  trial_type
+0.0     10.0      rest
+10.0    20.0      trial-1
+30.0    10.0      rest
+40.0    20.0      trial-2
+60.0    10.0      rest
+70.0    20.0      trial-3
+90.0    10.0      rest
+```
+
+events.json Segments as above. BOLD TR=2.0s, 50 TRs total.
+
+Resulting BoldMeta.segments:
+```python
+[
+    Segment(entity="trial", value="1", slice=slice(5, 15),  metadata={"cond": "R", "item": "101"}),
+    Segment(entity="trial", value="2", slice=slice(20, 30), metadata={"cond": "L", "item": "102"}),
+    Segment(entity="trial", value="3", slice=slice(35, 45), metadata={"cond": "R", "item": "103"}),
+]
+```
+
+TRs 0–4, 15–19, 30–34, 45–49 are break TRs — not indexed by any segment, excluded from X/Y.
+
+See [semantic-entity.md](semantic-entity.md) for segment entity inference rules.
+See [feature-files.md](feature-files.md) for feature file naming conventions.

--- a/notes/decisions/segment-metadata.md
+++ b/notes/decisions/segment-metadata.md
@@ -40,8 +40,8 @@ Within a single events.json (enforced in `bold.load_bold_meta`):
 - All records have identical metadata key sets (schema invariance).
 - No metadata key collides with BOLD identity entities (`sub`, `ses`, `task`, `acq`, `ce`,
   `rec`, `dir`, `run`). Encoding-pipeline reserved keys (`space`, `feature`) are rejected
-  later by `CellKey.EXCLUDE` during `_resolve_cell_keys` — keeping `bold.py` agnostic of
-  encoding-pipeline concerns.
+  by `CellKey.EXCLUDE` at `CellKey.__init__` during `_discover_features` — keeping
+  `bold.py` agnostic of encoding-pipeline concerns.
 
 ## Single-segment runs
 
@@ -61,75 +61,12 @@ Cross-run (enforced in `Encoding._discover_bold`):
   events.json (empty metadata) does not match a segmented run with populated metadata.
   Mixing the two raises rather than silently routing partial metadata downstream.
 
-## In-memory representation
-
-```python
-@dataclass(frozen=True)
-class Segment:
-    entity: str           # e.g. "trial"
-    value: str            # bare value, e.g. "1"
-    slice: slice          # TR-slice derived from events.tsv onset/duration
-    metadata: dict[str, str]  # e.g. {"cond": "R", "item": "101"}; empty if no SegmentMetadata
-
-class BoldMeta(NamedTuple):
-    bids: BIDSPath
-    repetition_time: float
-    segments: list[Segment]   # empty list if unsegmented run
-```
-
-Slices use bare values as keys (matching `Segment.value`) — the segment entity name is
-available on `Segment.entity` and is not redundantly embedded in the value.
-
 ## CellKey enrichment (`_resolve_cell_keys`)
 
-For each feature cell, `Segment.metadata` is merged into the cell's `CellKey`:
-
-```python
-enriched = CellKey(**{**dict(cell_key.items()), **segment.metadata})
-```
-
-Source-of-truth rule: events.json is authoritative for descriptive segment metadata. The
-feature filename carries only `ses`, `run`, and the segment entity. All other entities
-either belong to `CellKey.EXCLUDE` (invariant-across-training or image-variant entities,
-rejected at `CellKey` construction) or must come from events.json. Any descriptive entity
-on a feature filename that is absent from `seg.metadata` is rejected.
-
-Four filename × sidecar cases:
-- Sidecar-only (key in `seg.metadata`, absent from filename): merged onto enriched `CellKey`.
-- Both, same value: allowed; redundant but harmless.
-- Both, different value: raise — the two sources of truth disagree.
-- Filename-only descriptive (non-identity, non-segment, non-reserved key on filename, absent
-  from `seg.metadata`): raise, pointing user to events.json.
-
-After enrichment, all `bids_filters` (including metadata-entity filters like `cond-R`) apply
+`Segment.metadata` is merged into each feature cell's `CellKey` at enrichment time. After
+enrichment, all `bids_filters` (including metadata-entity filters like `cond-R`) apply
 uniformly against the enriched `CellKey`. No separate metadata-aware filter path needed.
 
-## Example — full picture
-
-events.tsv:
-```
-onset   duration  trial_type
-0.0     10.0      rest
-10.0    20.0      trial-1
-30.0    10.0      rest
-40.0    20.0      trial-2
-60.0    10.0      rest
-70.0    20.0      trial-3
-90.0    10.0      rest
-```
-
-events.json SegmentMetadata as above. BOLD TR=2.0s, 50 TRs total.
-
-Resulting BoldMeta.segments:
-```python
-[
-    Segment(entity="trial", value="1", slice=slice(5, 15),  metadata={"cond": "R", "item": "101"}),
-    Segment(entity="trial", value="2", slice=slice(20, 30), metadata={"cond": "L", "item": "102"}),
-    Segment(entity="trial", value="3", slice=slice(35, 45), metadata={"cond": "R", "item": "103"}),
-]
-```
-
-TRs 0–4, 15–19, 30–34, 45–49 are break TRs — not indexed by any segment, excluded from X/Y.
-
+See [feature-files.md](feature-files.md) for the four filename × sidecar merge cases and
+`CellKey` exclusion rules.
 See [semantic-entity.md](semantic-entity.md) for segment entity inference rules.
-See [feature-files.md](feature-files.md) for feature file naming conventions.

--- a/notes/decisions/semantic-entity.md
+++ b/notes/decisions/semantic-entity.md
@@ -51,7 +51,7 @@ segment slice and are excluded from X/Y.
 
 `CellKey` is the open-schema row key for a feature time window. After enrichment it carries:
 - Filename entities: `ses`, `run`, segment entity value (e.g. `trial=1`)
-- Metadata entities from `events.json` `Segments` (e.g. `cond=R`, `item=101`)
+- Metadata entities from `events.json` `SegmentMetadata` (e.g. `cond=R`, `item=101`)
 
 Excluded from `CellKey` (`CellKey.EXCLUDE`): `sub`, `task`, `acq`, `ce`, `rec`, `dir`
 (invariant within a training call), `desc`, `res`, `den`, `echo` (BOLD image-variant
@@ -93,5 +93,5 @@ be finer than the intended segment entity. Single-entity-only makes the intent u
 without requiring tiling-strictness.
 
 See [feature-files.md](feature-files.md) for feature file naming conventions.
-See [segment-metadata.md](segment-metadata.md) for the events.json `Segments` format.
+See [segment-metadata.md](segment-metadata.md) for the events.json `SegmentMetadata` format.
 See [../external/bids.md](../external/bids.md) for the BIDS entity reserved name list.

--- a/notes/decisions/semantic-entity.md
+++ b/notes/decisions/semantic-entity.md
@@ -53,9 +53,10 @@ segment slice and are excluded from X/Y.
 - Filename entities: `ses`, `run`, segment entity value (e.g. `trial=1`)
 - Metadata entities from `events.json` `Segments` (e.g. `cond=R`, `item=101`)
 
-Excluded from `CellKey`: `sub`, `task` (invariant within a training call), `feature` (column
-axis), `space` (BOLD-only). Entities are present or absent — no `None` sentinel. Equality and
-hashing are order-independent.
+Excluded from `CellKey` (`CellKey.EXCLUDE`): `sub`, `task`, `acq`, `ce`, `rec`, `dir`
+(invariant within a training call), `desc`, `res`, `den`, `echo` (BOLD image-variant
+derivatives), `space`, `feature` (orthogonal axes). Entities are present or absent — no
+`None` sentinel. Equality and hashing are order-independent.
 
 CV splits are expressed by querying `CellKey` entities:
 ```python
@@ -71,9 +72,8 @@ train = [s for k, s in data.row_slices.items() if k["trial"] == "1"]
 - All BOLD runs in a training call must agree on the segment entity name, or all be
   unsegmented. Mixed levels are incoherent for a single encoding model.
 - Unsegmented runs are valid — no key-value events required.
-- When all BOLD runs are unsegmented, extra entities on feature filenames beyond `ses`/`run`
-  are accepted as descriptive tags. Misalignment with intended-but-missing segmentation is
-  not detectable and surfaces only as unexpected row counts in X/Y.
+- For unsegmented runs, only `ses` and `run` are valid on feature filenames — any other
+  entity raises. Descriptive attributes must live in `events.json`.
 
 ## Rationale
 

--- a/notes/decisions/semantic-entity.md
+++ b/notes/decisions/semantic-entity.md
@@ -1,105 +1,97 @@
-# Semantic partition entities
+# Semantic segment entities
 
-Design record for hypline's structural entity inference — how the partition entity is
+Design record for hypline's structural entity inference — how the segment entity is
 identified from events.tsv, and the invariants it must satisfy.
 
 ## Motivation
 
-Users think in terms of study design entities (`block`, `trial`). Hypline infers the partition
-entity directly from the tiling structure of events.tsv — no framework-specific naming required.
+Users think in terms of study design entities (`block`, `trial`). Hypline infers the segment
+entity directly from events.tsv — no framework-specific naming required.
 
 ## events.tsv convention
 
-BIDS key-value `trial_type` rows (e.g. `block-1`, `trial-A`) declare partitions — they are
-treated as structural intent. Every such entity must tile the run; partial tiling is a hard
-error. Non-partition annotations must use flat (non-key-value) `trial_type` labels (e.g.
-`rest`, `fixation`).
+Exactly one BIDS key-value entity name may appear across all `trial_type` rows (e.g. all
+key-value rows use `trial-*`, never mixing `block-*` and `trial-*`). That entity is the
+segment entity. Rows with more than one distinct BIDS entity name raise.
+
+BIDS key-value rows declare segments — non-overlapping time windows within the run. Gaps
+(pauses, breaks) before, between, and after segments are allowed; segments do not need to
+tile the full run duration. Non-segment annotations must use flat (non-key-value) `trial_type`
+labels (e.g. `rest`, `fixation`).
+
+The segment entity name must not appear as a flat label in the same events.tsv (e.g. if
+`trial` is the segment entity, `trial_type=trial` is forbidden — too easy to confuse with
+`trial-1`).
 
 This convention is layered on top of the BIDS spec, which treats `trial_type` as a free-text
-label. Hypline restricts key-value format to partition declarations to keep structural intent
+label. Hypline restricts key-value format to segment declarations to keep structural intent
 unambiguous.
-
-Friction case: descriptive labels that happen to match key-value format (e.g. `cond-A` with no
-tiling intent) will be rejected as a partial-tiling error. Rename to a flat label (`condA`) if
-descriptive, or add rows to make it tile if structural.
 
 ## Definitions
 
-- **Partition entity**: the BIDS key-value entity in events.tsv whose values tile the run and
-  have the smallest average slice duration. Feature files are always provided at this
-  granularity. There must be exactly one per run — ties are a hard error.
-- **Unpartitioned run**: a run with no events file or an events file with no BIDS key-value
+- **Segment entity**: the single BIDS key-value entity name in events.tsv. Each value (e.g.
+  `1`, `2`) identifies one time window. Feature files must carry this entity.
+- **Unsegmented run**: a run with no events file or an events file with no BIDS key-value
   rows. The time window is the full run.
 
-## Tiling invariants
+## Segment invariants
 
-Every BIDS key-value entity in events.tsv must satisfy all of the following:
+Every segment (BIDS key-value row in events.tsv) must satisfy:
 
-1. All rows use valid BIDS `key-value` format (`BIDS_ENTITY_RE`: `^[a-z]+-[a-zA-Z0-9]+$`)
+1. `trial_type` matches `BIDS_ENTITY_RE` (`^[a-z]+-[a-zA-Z0-9]+$`)
 2. Zero-duration rows are excluded
-3. Slices start at TR 0 (onset of first value = 0)
-4. Slices are non-overlapping and contiguous (no gaps between consecutive slices)
-5. Max slice endpoint equals the events span (`max(onset + duration)` across all valid rows)
+3. Segment values within a run are globally unique (no per-block-resetting IDs)
+4. Slices are non-overlapping (gaps allowed anywhere — leading, trailing, between)
+5. `max(slice.stop) ≤ BOLD array length` — validated in `_build_xy` after loading arrays
 
-Condition 5 uses the events file's own span as the reference — not the BOLD array length.
-Full BOLD coverage is validated separately in `_build_xy` once arrays are loaded.
-
-Partial tiling — where some key-value entities tile and others do not — is a hard error.
-Use flat `trial_type` labels for any annotation that is not a partition.
+Full BOLD coverage is not required. Breaks consume TRs that are simply not indexed by any
+segment slice and are excluded from X/Y.
 
 ## CellKey
 
-`CellKey` is the open-schema row key for a feature time window. It stores all
-BIDS entities from a feature filename except those in `CellKey.EXCLUDE`:
-`sub` and `task` (invariant within a training call), `feature` (column axis,
-not row axis), and `space` (BOLD-only). Entities are present or absent — there
-is no `None` sentinel. Equality and hashing are order-independent.
+`CellKey` is the open-schema row key for a feature time window. After enrichment it carries:
+- Filename entities: `ses`, `run`, segment entity value (e.g. `trial=1`)
+- Metadata entities from `events.json` `Segments` (e.g. `cond=R`, `item=101`)
+
+Excluded from `CellKey`: `sub`, `task` (invariant within a training call), `feature` (column
+axis), `space` (BOLD-only). Entities are present or absent — no `None` sentinel. Equality and
+hashing are order-independent.
 
 CV splits are expressed by querying `CellKey` entities:
 ```python
-train = [s for k, s in data.row_slices.items() if k["block"] == "1"]
+train = [s for k, s in data.row_slices.items() if k["trial"] == "1"]
 ```
 
 ## Key invariants
 
-- Feature files are provided at the partition entity granularity — coarser or finer is not
-  supported. If a user wants `block`-level features, `block` must be the partition entity.
-- Multiple key-value entities in one run are allowed (e.g. `block` and `trial`); all must
-  tile, and the finest (smallest average duration) is selected as the partition entity. Equal
-  granularity is a degenerate design and raises.
-- All BOLD runs in a training call must agree on the partition entity name, or all be
-  unpartitioned. Mixed levels are incoherent for a single encoding model — TR-slice semantics
-  differ across rows, making regularisation and CV splits incomparable.
-- Unpartitioned runs are valid — no key-value events required.
-- When all BOLD runs are unpartitioned, extra entities on feature filenames beyond `ses`/`run`
-  are accepted as descriptive tags (e.g. `cond-A` for grouping or filtering). If those entities
-  were intended as partition keys but events.tsv is absent or contains no BIDS key-value rows,
-  the misalignment is not detectable and surfaces only as unexpected row counts in X/Y. Use
-  flat `trial_type` labels in events.tsv if annotations are non-structural, or add a tiling
-  events.tsv if partitioning is intended.
+- Feature files carry the segment entity — coarser or finer granularity is not supported.
+- Exactly one BIDS key-value entity name per run — multiple segment-level entities (e.g.
+  both `block-*` and `trial-*` rows) are a hard error. Use the finest granularity needed
+  and express coarser groupings via `events.json` metadata.
+- All BOLD runs in a training call must agree on the segment entity name, or all be
+  unsegmented. Mixed levels are incoherent for a single encoding model.
+- Unsegmented runs are valid — no key-value events required.
+- When all BOLD runs are unsegmented, extra entities on feature filenames beyond `ses`/`run`
+  are accepted as descriptive tags. Misalignment with intended-but-missing segmentation is
+  not detectable and surfaces only as unexpected row counts in X/Y.
 
 ## Rationale
 
 **Why key-value `trial_type` rather than side columns.** BIDS' idiomatic answer for
 intra-run hierarchy is extra columns alongside `trial_type` (e.g. a `block` column on
-each trial row), consumed by FSL/SPM/nilearn/fitlins as a flat DataFrame. Hypline
-diverges because its model requires partitions to *tile the run* — every TR belongs
-to exactly one slice. Deriving partition onset/duration from trial-level rows
-requires gap-filling heuristics (does block-1 start at run start or first trial?
-does it own inter-trial gaps?), and each choice changes TR-to-partition assignment
-and therefore the science. Explicit tiling rows make that judgment author-controlled
-and reviewable rather than hidden in inference.
+each trial row). Hypline diverges because encoding requires explicit per-segment onset and
+duration — deriving these from trial-level rows requires gap-filling heuristics that change
+TR-to-segment assignment and therefore the science. Explicit segment rows make that judgment
+author-controlled and reviewable.
 
-**Multi-scale events.** Treating `block-1` as a 10s-duration row alongside trial rows
-is a deliberate divergence from the dominant GLM-centric reading where `trial_type`
-rows are stimulus occurrences. BIDS' minimal definition of "event" (anything with
-onset + duration) accommodates both readings; hypline picks the multi-scale one. An
-events.tsv authored for hypline is not a drop-in for nilearn/fitlins GLM calls.
+**Why globally unique values.** Per-block-resetting trial IDs (`trial-1..trial-N` per block)
+are permitted by BIDS and common in raw logs, but must be rewritten upstream before ingestion.
 
-**Why globally unique values.** Hypline requirement, not a BIDS norm. Per-block-resetting
-trial IDs (`trial-1..trial-N` per block) are permitted by BIDS and common in raw logs,
-but must be rewritten upstream before ingestion. Hierarchical tiling — `(block, trial)`
-tuples unique but `trial` alone repeating — is therefore not supported.
+**Why single entity, not finest-granularity tiebreaker.** Multi-entity events.tsv under a
+non-overlap-only rule would silently pick the wrong level if a descriptive entity happened to
+be finer than the intended segment entity. Single-entity-only makes the intent unambiguous
+without requiring tiling-strictness.
 
 See [feature-files.md](feature-files.md) for feature file naming conventions.
+See [segment-metadata.md](segment-metadata.md) for the events.json `Segments` format.
 See [../external/bids.md](../external/bids.md) for the BIDS entity reserved name list.

--- a/notes/decisions/semantic-entity.md
+++ b/notes/decisions/semantic-entity.md
@@ -47,22 +47,6 @@ Every segment (BIDS key-value row in events.tsv) must satisfy:
 Full BOLD coverage is not required. Breaks consume TRs that are simply not indexed by any
 segment slice and are excluded from X/Y.
 
-## CellKey
-
-`CellKey` is the open-schema row key for a feature time window. After enrichment it carries:
-- Filename entities: `ses`, `run`, segment entity value (e.g. `trial=1`)
-- Metadata entities from `events.json` `SegmentMetadata` (e.g. `cond=R`, `item=101`)
-
-Excluded from `CellKey` (`CellKey.EXCLUDE`): `sub`, `task`, `acq`, `ce`, `rec`, `dir`
-(invariant within a training call), `desc`, `res`, `den`, `echo` (BOLD image-variant
-derivatives), `space`, `feature` (orthogonal axes). Entities are present or absent — no
-`None` sentinel. Equality and hashing are order-independent.
-
-CV splits are expressed by querying `CellKey` entities:
-```python
-train = [s for k, s in data.row_slices.items() if k["trial"] == "1"]
-```
-
 ## Key invariants
 
 - Feature files carry the segment entity — coarser or finer granularity is not supported.
@@ -92,6 +76,6 @@ non-overlap-only rule would silently pick the wrong level if a descriptive entit
 be finer than the intended segment entity. Single-entity-only makes the intent unambiguous
 without requiring tiling-strictness.
 
-See [feature-files.md](feature-files.md) for feature file naming conventions.
+See [feature-files.md](feature-files.md) for feature file naming conventions and `CellKey` rules.
 See [segment-metadata.md](segment-metadata.md) for the events.json `SegmentMetadata` format.
 See [../external/bids.md](../external/bids.md) for the BIDS entity reserved name list.

--- a/notes/external/bids.md
+++ b/notes/external/bids.md
@@ -40,6 +40,27 @@ Check the BIDS spec before introducing a new custom entity.
 
 ## Structural entities in hypline
 
-Hypline does not register a fixed entity name for partitions. User-chosen BIDS key-value
-names in events.tsv (e.g. `block`, `trial`) are inferred as structural at discovery time
-via a tiling check. See [../decisions/semantic-entity.md](../decisions/semantic-entity.md).
+Hypline does not register a fixed segment entity name. User-chosen BIDS key-value names in
+events.tsv (e.g. `block`, `trial`) are inferred as the segment entity at discovery time —
+exactly one entity name is allowed per run. See
+[../decisions/semantic-entity.md](../decisions/semantic-entity.md).
+
+## Sidecar naming — two categories
+
+BIDS sidecars fall into two naming categories that hypline handles via separate code paths:
+
+- **Per-file sidecars** (e.g. `*_bold.json`, `*_T1w.json`). Mirror the full stem of the
+  data file they describe — including non-identity entities like `space`, `desc`. Resolved
+  by stripping the imaging extension and swapping in `.json`. A run with multiple BOLD
+  variants (different `space`, `desc`) has multiple `*_bold.json` files, one per variant.
+  Implemented in `bold.get_repetition_time`.
+
+- **Run-level sidecars** (e.g. `*_events.tsv`, `*_events.json`, `*_physio.tsv.gz`). Named
+  using identity entities only (`sub`, `ses`, `task`, `acq`, `ce`, `rec`, `dir`, `run`) —
+  describe the source data, invariant across `space`/`desc`/etc. One sidecar per run,
+  shared by all derived variants. Implemented in `bold._resolve_run_sidecar`.
+
+The discrepancy is mandated by BIDS (events.tsv may not carry `space`, `desc`, etc.; per-file
+sidecars must mirror their target file). Conflating the two would either over-restrict
+per-file sidecars (rejecting valid `space-T1w_bold.json`) or under-restrict run-level
+sidecars (allowing divergent `space-T1w_events.tsv` and `space-MNI_events.tsv`).

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -31,7 +31,7 @@ A single `train(sub_id)` call is scoped to:
 1. **`_discover_features`** — scans feature filenames for `sub_id`; returns raw
    `dict[FeatureKey, Path]` with filename-only `CellKey`s. No events I/O. No user filters.
 2. **`_discover_bold`** — scans BOLD filenames; reads sidecar JSON (TR), events.tsv
-   (segment slices), and events.json `Segments` (metadata). Returns
+   (segment slices), and events.json `SegmentMetadata` (metadata). Returns
    `dict[BoldKey, BoldMeta]`. Validates within-run and cross-run segment invariants. No user filters.
 3. **`_resolve_cell_keys`** — validates filename entities against events.json and
    merges `Segment.metadata` onto each feature cell's `CellKey`. Rejects illegal
@@ -111,7 +111,7 @@ before any empty-result `FileNotFoundError`.
   [../decisions/feature-files.md](../decisions/feature-files.md).
 - **Segment contract** (single entity, non-overlap, cross-run agreement, cell schema
   invariance): see [../decisions/semantic-entity.md](../decisions/semantic-entity.md).
-- **Segment metadata contract** (events.json `Segments` format, enrichment, filtering):
+- **Segment metadata contract** (events.json `SegmentMetadata` format, enrichment, filtering):
   see [../decisions/segment-metadata.md](../decisions/segment-metadata.md).
 - **One feature file per (CellKey, feature) pair.** Multiple files for the same pair is
   ambiguous provenance, not something to merge.

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -18,10 +18,30 @@ A single `train(sub_id)` call is scoped to:
   BOLD or feature files, the pipeline raises.
 - **Multiple sessions and runs: allowed and expected.** Same task, more
   data — concatenated into a single X/Y.
-- **Multiple cells per run: allowed.** The partition entity is inferred from
-  events.tsv at discovery time. Each partition value is a separate row block,
-  identified by a `CellKey` carrying all non-excluded filename entities.
+- **Multiple cells per run: allowed.** The segment entity is inferred from
+  events.tsv at discovery time. Each segment value is a separate row block,
+  identified by a `CellKey` carrying all non-excluded entities (filename +
+  enriched metadata).
   See [../decisions/semantic-entity.md](../decisions/semantic-entity.md).
+
+## Pipeline
+
+`train(sub_id)` executes these steps in order:
+
+1. **`_discover_features`** — scans feature filenames for `sub_id`; returns raw
+   `dict[FeatureKey, Path]` with filename-only `CellKey`s. No events I/O.
+2. **`_discover_bold`** — scans BOLD filenames; reads sidecar JSON (TR), events.tsv
+   (segment slices), and events.json `Segments` (metadata). Returns
+   `dict[BoldKey, BoldMeta]`. Validates within-run and cross-run segment invariants.
+3. **`_validate_coverage`** — checks `sub`/`task` invariance across all files and
+   bidirectional `ses`/`run` coverage between features and BOLD. Void-returning.
+4. **`_enrich_cells`** — joins each feature cell's `CellKey` with its run's
+   `Segment.metadata` from `BoldMeta`. Applies conflict rule (raise on value mismatch,
+   allow agreement). Returns enriched `dict[FeatureKey, Path]`.
+5. **`_apply_feature_filters`** — applies user `bids_filters` to enriched cells;
+   runs typo diagnostic against enriched-`CellKey` entity schema.
+6. **`_build_xy`** — loads BOLD arrays; validates `max(slice.stop) ≤ BOLD TRs`;
+   assembles X (features) and Y (BOLD) matrices.
 
 ## Alignment contract
 
@@ -41,8 +61,7 @@ Coverage failures are reported fail-fast: the first missing (cell, feature)
 pair raises, without aggregating the full list. Mismatches are typically
 systematic (e.g. an entire feature missing across all cells from a failed
 extraction run), so the first gap is enough signal for the user to fix the
-root cause and rerun. Aggregating would flood the message without changing
-what the user does next.
+root cause and rerun.
 
 ## Module layout
 
@@ -56,24 +75,25 @@ intentional — fMRIPrep derivatives are often organized in per-subject subdirec
 
 ## `bids_filters` routing
 
-User-supplied `bids_filters` are routed automatically — no need to specify separate feature
-vs. BOLD filters:
+User-supplied `bids_filters` are applied in two places:
 
-- **Shared entities** (`ses`, `task`, `run`): forwarded to both feature and BOLD discovery.
-- **BOLD-exclusive entities** (`desc`, `res`, `den`, `echo`, `acq`, `ce`, `rec`, `dir`):
-  forwarded to BOLD discovery only; stripped from feature-side filters since feature files
-  never carry them.
-- **Feature entities** (any other entity, e.g. `block-1`): forwarded to feature discovery
-  only.
+- **BOLD discovery (`_discover_bold`)**: BOLD-exclusive entities (`desc`, `res`, `den`,
+  `echo`, `acq`, `ce`, `rec`, `dir`) and shared structural entities (`ses`, `task`, `run`)
+  filter at `find_files` time against BOLD filenames.
+- **Post-enrichment (`_apply_feature_filters`)**: all remaining user filters (including
+  metadata entities like `cond-R`) apply against enriched `CellKey`s after `_enrich_cells`.
+  This is necessary because metadata entities do not appear on feature filenames — they are
+  only available after events.json is loaded and joined.
+
+Feature-side `find_files` uses only hard-coded structural filters (`sub`, segment entity
+when known). User filters are not applied to feature filenames directly.
+
 - **Reserved entities** (`sub`, `space`, `feature`): rejected at construction — use the
   dedicated arguments instead.
 
-Filter entity validation is **fail-then-diagnose**: when filtered discovery yields no files
-but an unfiltered scan finds some, every filter entity is checked against the union of keys
-on those files — any absent entity raises `ValueError` before `FileNotFoundError`. This
-applies uniformly to all entity types including `ses`, `task`, `run` — no exemptions.
-Rationale: a session-less dataset has no `ses` on filenames; filtering on `ses-99` against
-such a dataset is a misuse worth flagging, not silently absorbing.
+Filter entity validation is **fail-then-diagnose**: when post-enrichment filtering yields no
+cells but enriched cells exist, every filter entity is checked against the union of keys on
+enriched cells — any absent entity raises `ValueError` before `FileNotFoundError`.
 
 ## Assumptions that could break
 
@@ -81,7 +101,9 @@ such a dataset is a misuse worth flagging, not silently absorbing.
   need per-run TR handling.
 - **Feature files mirror BOLD identity entities.** See
   [../decisions/feature-files.md](../decisions/feature-files.md).
-- **Partition contract** (inference, tiling, cross-run agreement, cell schema invariance):
-  see [../decisions/semantic-entity.md](../decisions/semantic-entity.md).
+- **Segment contract** (single entity, non-overlap, cross-run agreement, cell schema
+  invariance): see [../decisions/semantic-entity.md](../decisions/semantic-entity.md).
+- **Segment metadata contract** (events.json `Segments` format, enrichment, filtering):
+  see [../decisions/segment-metadata.md](../decisions/segment-metadata.md).
 - **One feature file per (CellKey, feature) pair.** Multiple files for the same pair is
   ambiguous provenance, not something to merge.

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -33,16 +33,17 @@ A single `train(sub_id)` call is scoped to:
 2. **`_discover_bold`** — scans BOLD filenames; reads sidecar JSON (TR), events.tsv
    (segment slices), and events.json `SegmentMetadata` (metadata). Returns
    `dict[BoldKey, BoldMeta]`. Validates within-run and cross-run segment invariants. No user filters.
-3. **`_resolve_cell_keys`** — validates filename entities against events.json and
-   merges `Segment.metadata` onto each feature cell's `CellKey`. Rejects illegal
-   filename entities. Raises on value mismatch between filename and sidecar. Returns
-   resolved `dict[FeatureKey, Path]`.
+3. **`_resolve_cell_keys`** — precondition: every feature's `(ses, run)` must map to a
+   `BoldMeta` (raises `FileNotFoundError` if not — required to read segments for
+   enrichment). Then merges `Segment.metadata` onto each feature cell's `CellKey`.
+   Rejects illegal filename entities. Raises on value mismatch between filename and
+   sidecar. Returns resolved `dict[FeatureKey, Path]`.
 4. **`_apply_filters`** — applies user `bids_filters` to both enriched feature cells
    and BOLD runs. Raises on typo (filter key absent from enriched schema). Returns
    filtered `(dict[FeatureKey, Path], dict[BoldKey, BoldMeta])`.
-5. **`_validate_coverage`** — checks `sub`/`task` invariance across all files and
-   bidirectional `ses`/`run` coverage between filtered features and BOLD. Raises if
-   either side is empty. Void-returning.
+5. **`_validate_coverage`** — checks `sub`/`task` invariance across all files.
+   Bidirectional `ses`/`run` coverage: every filtered BOLD run must have feature
+   coverage and vice versa. Raises if either filtered set is empty. Void-returning.
 6. **`_build_xy`** — loads BOLD arrays; validates `max(slice.stop) ≤ BOLD TRs`;
    assembles X (features) and Y (BOLD) matrices.
 

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -29,17 +29,20 @@ A single `train(sub_id)` call is scoped to:
 `train(sub_id)` executes these steps in order:
 
 1. **`_discover_features`** — scans feature filenames for `sub_id`; returns raw
-   `dict[FeatureKey, Path]` with filename-only `CellKey`s. No events I/O.
+   `dict[FeatureKey, Path]` with filename-only `CellKey`s. No events I/O. No user filters.
 2. **`_discover_bold`** — scans BOLD filenames; reads sidecar JSON (TR), events.tsv
    (segment slices), and events.json `Segments` (metadata). Returns
-   `dict[BoldKey, BoldMeta]`. Validates within-run and cross-run segment invariants.
-3. **`_validate_coverage`** — checks `sub`/`task` invariance across all files and
-   bidirectional `ses`/`run` coverage between features and BOLD. Void-returning.
-4. **`_enrich_cells`** — joins each feature cell's `CellKey` with its run's
-   `Segment.metadata` from `BoldMeta`. Applies conflict rule (raise on value mismatch,
-   allow agreement). Returns enriched `dict[FeatureKey, Path]`.
-5. **`_apply_feature_filters`** — applies user `bids_filters` to enriched cells;
-   runs typo diagnostic against enriched-`CellKey` entity schema.
+   `dict[BoldKey, BoldMeta]`. Validates within-run and cross-run segment invariants. No user filters.
+3. **`_resolve_cell_keys`** — validates filename entities against events.json and
+   merges `Segment.metadata` onto each feature cell's `CellKey`. Rejects illegal
+   filename entities. Raises on value mismatch between filename and sidecar. Returns
+   resolved `dict[FeatureKey, Path]`.
+4. **`_apply_filters`** — applies user `bids_filters` to both enriched feature cells
+   and BOLD runs. Raises on typo (filter key absent from enriched schema). Returns
+   filtered `(dict[FeatureKey, Path], dict[BoldKey, BoldMeta])`.
+5. **`_validate_coverage`** — checks `sub`/`task` invariance across all files and
+   bidirectional `ses`/`run` coverage between filtered features and BOLD. Raises if
+   either side is empty. Void-returning.
 6. **`_build_xy`** — loads BOLD arrays; validates `max(slice.stop) ≤ BOLD TRs`;
    assembles X (features) and Y (BOLD) matrices.
 
@@ -75,25 +78,30 @@ intentional — fMRIPrep derivatives are often organized in per-subject subdirec
 
 ## `bids_filters` routing
 
-User-supplied `bids_filters` are applied in two places:
+All user-supplied `bids_filters` are applied post-resolution in `_apply_filters` against
+resolved `CellKey`s (features) and BOLD filename entities (BOLD). Neither `_discover_features`
+nor `_discover_bold` apply user filters — both use only hard-coded structural filters
+(`sub`, `feature`, `space`).
 
-- **BOLD discovery (`_discover_bold`)**: BOLD-exclusive entities (`desc`, `res`, `den`,
-  `echo`, `acq`, `ce`, `rec`, `dir`) and shared structural entities (`ses`, `task`, `run`)
-  filter at `find_files` time against BOLD filenames.
-- **Post-enrichment (`_apply_feature_filters`)**: all remaining user filters (including
-  metadata entities like `cond-R`) apply against enriched `CellKey`s after `_enrich_cells`.
-  This is necessary because metadata entities do not appear on feature filenames — they are
-  only available after events.json is loaded and joined.
-
-Feature-side `find_files` uses only hard-coded structural filters (`sub`, segment entity
-when known). User filters are not applied to feature filenames directly.
+Rationale: metadata entities (e.g. `cond-R`) do not exist on filenames and cannot be routed
+to `find_files`. Applying all filters uniformly post-resolution ensures consistent behaviour
+whether the filter targets a structural entity (`ses-1`) or a descriptive one (`cond-R`).
 
 - **Reserved entities** (`sub`, `space`, `feature`): rejected at construction — use the
   dedicated arguments instead.
 
-Filter entity validation is **fail-then-diagnose**: when post-enrichment filtering yields no
-cells but enriched cells exist, every filter entity is checked against the union of keys on
-enriched cells — any absent entity raises `ValueError` before `FileNotFoundError`.
+**Match semantics:** multiple filters sharing the same entity key OR-match within that group;
+different entity keys AND-match across groups (e.g. `["task-rest", "task-nback", "ses-1"]`
+selects runs where task is rest or nback, AND session is 1). This mirrors `find_files` behaviour.
+
+**Asymmetric schemas:** feature cells and BOLD files do not share the same entity key set
+(e.g. `task` is excluded from `CellKey` but present on BOLD filenames). A filter key absent
+from one side is silently skipped on that side — it applies only where the entity is meaningful.
+A filter key absent from *both* sides raises `ValueError` (typo diagnostic).
+
+Filter entity validation is **fail-then-diagnose**: every filter entity is checked against the
+union of resolved cell keys and BOLD filename keys — any absent entity raises `ValueError`
+before any empty-result `FileNotFoundError`.
 
 ## Assumptions that could break
 

--- a/src/hypline/bids.py
+++ b/src/hypline/bids.py
@@ -3,6 +3,8 @@ import re
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
+BIDS_ENTITY_KEY_RE = re.compile(r"^[a-z]+$")
+BIDS_ENTITY_VALUE_RE = re.compile(r"^[a-zA-Z0-9]+$")
 BIDS_ENTITY_RE = re.compile(r"^[a-z]+-[a-zA-Z0-9]+$")
 _BIDS_SUFFIX_RE = re.compile(r"^[a-zA-Z0-9]+$")
 

--- a/src/hypline/bold.py
+++ b/src/hypline/bold.py
@@ -251,7 +251,7 @@ def _validate_segment_records(
     segment_records: list[dict],
     segments: list[Segment],
 ) -> None:
-    """Validate events.json `Segments` records against events.tsv-parsed segments.
+    """Validate `SegmentMetadata` records in events.json against segments in events.tsv.
 
     Each record describes one segment and carries the segment-entity key plus
     arbitrary metadata keys. Raises ValueError on missing segment-entity key,
@@ -264,7 +264,7 @@ def _validate_segment_records(
     for record in segment_records:
         if segment_entity not in record:
             raise ValueError(
-                f"events.json Segments record is missing segment entity key "
+                f"events.json SegmentMetadata record is missing segment entity key "
                 f"{segment_entity!r}: {record}"
             )
 
@@ -273,7 +273,7 @@ def _validate_segment_records(
         missing = sorted(expected_values - record_values)
         extra = sorted(record_values - expected_values)
         raise ValueError(
-            f"events.json Segments values do not match events.tsv. "
+            f"events.json SegmentMetadata values do not match events.tsv. "
             f"Missing: {missing}, extra: {extra}"
         )
 
@@ -283,7 +283,7 @@ def _validate_segment_records(
     ]
     if len(set(metadata_keys_per_record)) > 1:
         raise ValueError(
-            "events.json Segments records have inconsistent metadata keys — "
+            "events.json SegmentMetadata records have inconsistent metadata keys — "
             "all records must carry the same set of metadata keys"
         )
     metadata_keys = metadata_keys_per_record[0]
@@ -317,7 +317,7 @@ def _validate_segment_records(
 def load_bold_meta(bold_path: str | os.PathLike[str]) -> BoldMeta:
     """Load all metadata for a BOLD run: TR, segments, and segment metadata.
 
-    Segment metadata is sourced from the colocated events.json `Segments` field
+    Segment metadata is sourced from the colocated events.json `SegmentMetadata` field
     and merged into each `Segment.metadata`. If no events.json is present,
     segments have empty metadata dicts.
 
@@ -330,13 +330,15 @@ def load_bold_meta(bold_path: str | os.PathLike[str]) -> BoldMeta:
     events_json = load_events_json(bold_path)
 
     segments = _parse_segments(events, repetition_time)
-    segment_records: list[dict] = events_json.get("Segments", []) if events_json else []
+    segment_records: list[dict] = (
+        events_json.get("SegmentMetadata", []) if events_json else []
+    )
     if segment_records:
         if not segments:
             raise ValueError(
-                "events.json has a Segments field but events.tsv has no BIDS "
-                "key-value rows — add segment rows to events.tsv or remove Segments "
-                "from events.json"
+                "events.json has a SegmentMetadata field but events.tsv "
+                "has no BIDS key-value rows — add segment rows to events.tsv "
+                "or remove SegmentMetadata from events.json"
             )
         _validate_segment_records(segment_records, segments)
         segment_entity = segments[0].entity

--- a/src/hypline/bold.py
+++ b/src/hypline/bold.py
@@ -94,7 +94,7 @@ class Segment:
 
 
 class BoldMeta(NamedTuple):
-    path: Path
+    bids: BIDSPath
     repetition_time: float
     segments: list[Segment]
 
@@ -351,4 +351,8 @@ def load_bold_meta(bold_path: str | os.PathLike[str]) -> BoldMeta:
             for seg in segments
         ]
 
-    return BoldMeta(path=bold_path, repetition_time=repetition_time, segments=segments)
+    return BoldMeta(
+        bids=BIDSPath(bold_path),
+        repetition_time=repetition_time,
+        segments=segments,
+    )

--- a/src/hypline/bold.py
+++ b/src/hypline/bold.py
@@ -1,9 +1,17 @@
+import json
 import os
+from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import NamedTuple
 
 import polars as pl
 
-from hypline.bids import BIDSPath
+from hypline.bids import (
+    BIDS_ENTITY_KEY_RE,
+    BIDS_ENTITY_RE,
+    BIDS_ENTITY_VALUE_RE,
+    BIDSPath,
+)
 from hypline.enums import SurfaceSpace, VolumeSpace
 
 _BOLD_IDENTITY_ENTITIES = frozenset(
@@ -42,30 +50,13 @@ def _strip_bold_extension(bold_path: Path) -> str:
 
 
 def get_repetition_time(bold_path: str | os.PathLike[str]) -> float:
+    """Extract the repetition time (TR) in seconds from a BOLD file.
+
+    Reads TR from the BIDS JSON sidecar if available, otherwise falls back to
+    the NIfTI header for volume data or GIfTI darray metadata for surface data.
+    Raises ValueError if TR is zero/unset in the NIfTI header, missing from
+    GIfTI metadata, or the image format is unsupported.
     """
-    Extract the repetition time (TR) in seconds from a BOLD file.
-
-    Reads TR from the BIDS JSON sidecar if available, otherwise
-    falls back to the NIfTI header for volume data or GIfTI darray
-    metadata for surface data.
-
-    Parameters
-    ----------
-    bold_path : str or os.PathLike
-        Path to a BOLD file (.nii, .nii.gz, or .func.gii).
-
-    Returns
-    -------
-    float
-        Repetition time in seconds.
-
-    Raises
-    ------
-    ValueError
-        If TR cannot be determined from any source.
-    """
-    import json
-
     import nibabel as nib
 
     bold_path = Path(bold_path)
@@ -94,34 +85,270 @@ def get_repetition_time(bold_path: str | os.PathLike[str]) -> float:
     raise ValueError(f"Unsupported image format: {type(img).__name__}")
 
 
-def load_events(bold_path: str | os.PathLike[str]) -> pl.DataFrame | None:
-    """Load the events TSV colocated with a BOLD file, or return None.
+@dataclass(frozen=True)
+class Segment:
+    entity: str
+    value: str
+    slice: slice
+    metadata: dict[str, str]
 
-    Events must be named with identity entities only (no space, desc, etc.)
-    in canonical BIDS order. If any file in the same directory shares this
-    run's identity entities but is not the canonical name, raises rather than
-    silently ignoring it — same run implies same stimulus timeline, so such
-    variants are either redundant or divergent, and both cases warrant surfacing.
+
+class BoldMeta(NamedTuple):
+    path: Path
+    repetition_time: float
+    segments: list[Segment]
+
+
+def _resolve_run_sidecar(
+    bold_path: str | os.PathLike[str],
+    suffix: str,
+    extension: str,
+) -> Path:
+    """Return the canonical run-level sidecar path for a BOLD file.
+
+    Run-level sidecars (events.tsv, events.json, physio.tsv.gz, etc.) are named
+    using the run's identity entities only — they describe the source data, not
+    a specific image variant, and are invariant across `space`, `desc`, etc.
+    Distinct from file-level sidecars like `*_bold.json` (which mirror the full
+    image stem and are resolved separately by suffix swap).
+
+    Returns the canonical path; may not exist (callers check). Raises if a file
+    in the same directory matches identity entities and the same suffix/extension
+    but is not the canonical name.
     """
     bids = BIDSPath(bold_path)
     shared = {k: v for k, v in bids.entities.items() if k in _BOLD_IDENTITY_ENTITIES}
     stem = "_".join(f"{k}-{v}" for k, v in shared.items())
-    events_file = bids.path.parent / (stem + "_events.tsv")
-    if events_file.exists():
-        return pl.read_csv(events_file, separator="\t")
+    canonical = bids.path.parent / f"{stem}_{suffix}{extension}"
 
-    misnamed_siblings = [
+    misnamed = [
         p
-        for p in bids.path.parent.glob("*_events.tsv")
-        if p != events_file
+        for p in bids.path.parent.glob(f"*_{suffix}{extension}")
+        if p != canonical
         and all(BIDSPath(p).entities.get(k) == v for k, v in shared.items())
     ]
-    if misnamed_siblings:
+    if misnamed:
         raise ValueError(
-            f"Expected {events_file.name!r} but found unexpected events file(s) "
-            "colocated with this BOLD run: "
-            f"{[p.name for p in sorted(misnamed_siblings)]}. "
+            f"Expected {canonical.name!r} but found unexpected {suffix}{extension} "
+            f"file(s) colocated with this BOLD run: "
+            f"{[p.name for p in sorted(misnamed)]}. "
             "Rename to use identity entities only in canonical BIDS order."
         )
 
+    return canonical
+
+
+def load_events_tsv(bold_path: str | os.PathLike[str]) -> pl.DataFrame | None:
+    """Load events TSV colocated with a BOLD file, or return None if absent.
+
+    Raises ValueError if a misnamed sibling sharing this run's identity entities
+    is found — same run implies same stimulus timeline, so variants are either
+    redundant or divergent and both cases warrant surfacing.
+    """
+    events_tsv_file = _resolve_run_sidecar(bold_path, "events", ".tsv")
+    if events_tsv_file.exists():
+        return pl.read_csv(events_tsv_file, separator="\t")
     return None
+
+
+def load_events_json(bold_path: str | os.PathLike[str]) -> dict | None:
+    """Load events JSON sidecar colocated with a BOLD file, or return None if absent.
+
+    Raises ValueError if a misnamed sibling sharing this run's identity entities
+    is found — same run implies same stimulus timeline, so variants are either
+    redundant or divergent and both cases warrant surfacing.
+    """
+    events_json_file = _resolve_run_sidecar(bold_path, "events", ".json")
+    if events_json_file.exists():
+        with open(events_json_file) as f:
+            return json.load(f)
+    return None
+
+
+def _parse_segments(
+    events: pl.DataFrame | None,
+    repetition_time: float,
+) -> list[Segment]:
+    """Parse BIDS key-value `trial_type` rows into segments.
+
+    Rows matching `entity-value` with duration > 0 become segments. Flat
+    labels (e.g. `rest`) are silently ignored. Returns [] for unsegmented runs.
+
+    Raises ValueError if:
+    - More than one distinct entity name is found across matching rows.
+    - The segment entity name also appears as a flat label in the same file.
+    - Any segment value appears more than once.
+    - Any two segment slices overlap.
+    """
+    if events is None:
+        return []
+
+    segment_rows = events.filter(
+        pl.col("trial_type").str.contains(BIDS_ENTITY_RE.pattern)
+        & (pl.col("duration") > 0.0)
+    )
+
+    if segment_rows.is_empty():
+        return []
+
+    segments: list[Segment] = []
+    for row in segment_rows.iter_rows(named=True):
+        entity, value = row["trial_type"].split("-", 1)
+        onset_tr = round(row["onset"] / repetition_time)
+        n_trs = round(row["duration"] / repetition_time)
+        segments.append(
+            Segment(
+                entity=entity,
+                value=value,
+                slice=slice(onset_tr, onset_tr + n_trs),
+                metadata={},
+            )
+        )
+
+    entity_names = {seg.entity for seg in segments}
+    if len(entity_names) > 1:
+        raise ValueError(
+            f"events.tsv contains multiple BIDS key-value entities "
+            f"{sorted(entity_names)} — only one segment entity allowed per run"
+        )
+    segment_entity = next(iter(entity_names))
+
+    flat_labels = set(
+        events.filter(~pl.col("trial_type").str.contains(BIDS_ENTITY_RE.pattern))[
+            "trial_type"
+        ].to_list()
+    )
+    if segment_entity in flat_labels:
+        raise ValueError(
+            f"Segment entity {segment_entity!r} also appears as a flat label in "
+            f"events.tsv — rename either the entity or the flat label"
+        )
+
+    values_seen: set[str] = set()
+    for seg in segments:
+        if seg.value in values_seen:
+            raise ValueError(
+                f"Segment value {segment_entity}-{seg.value} appears more than once in "
+                f"events.tsv — segment values must be unique within a run"
+            )
+        values_seen.add(seg.value)
+
+    segments = sorted(segments, key=lambda seg: seg.slice.start)
+
+    for prev, curr in zip(segments, segments[1:]):
+        if prev.slice.stop > curr.slice.start:
+            raise ValueError(
+                f"Segment slices overlap: {segment_entity}-{prev.value} "
+                f"[{prev.slice.start}:{prev.slice.stop}] and "
+                f"{segment_entity}-{curr.value} "
+                f"[{curr.slice.start}:{curr.slice.stop}]"
+            )
+
+    return segments
+
+
+def _validate_segment_records(
+    segment_records: list[dict],
+    segments: list[Segment],
+) -> None:
+    """Validate events.json `Segments` records against events.tsv-parsed segments.
+
+    Each record describes one segment and carries the segment-entity key plus
+    arbitrary metadata keys. Raises ValueError on missing segment-entity key,
+    value-set mismatch with events.tsv, inconsistent metadata schemas across
+    records, malformed metadata keys, or collisions with BOLD identity entities.
+    """
+    segment_entity = segments[0].entity
+    expected_values = {seg.value for seg in segments}
+
+    for record in segment_records:
+        if segment_entity not in record:
+            raise ValueError(
+                f"events.json Segments record is missing segment entity key "
+                f"{segment_entity!r}: {record}"
+            )
+
+    record_values = {record[segment_entity] for record in segment_records}
+    if record_values != expected_values:
+        missing = sorted(expected_values - record_values)
+        extra = sorted(record_values - expected_values)
+        raise ValueError(
+            f"events.json Segments values do not match events.tsv. "
+            f"Missing: {missing}, extra: {extra}"
+        )
+
+    metadata_keys_per_record = [
+        frozenset(k for k in record if k != segment_entity)
+        for record in segment_records
+    ]
+    if len(set(metadata_keys_per_record)) > 1:
+        raise ValueError(
+            "events.json Segments records have inconsistent metadata keys — "
+            "all records must carry the same set of metadata keys"
+        )
+    metadata_keys = metadata_keys_per_record[0]
+
+    for metadata_key in metadata_keys:
+        if not BIDS_ENTITY_KEY_RE.match(metadata_key):
+            raise ValueError(
+                f"events.json metadata key {metadata_key!r} is invalid — "
+                f"keys must match {BIDS_ENTITY_KEY_RE.pattern}"
+            )
+        if metadata_key in _BOLD_IDENTITY_ENTITIES:
+            raise ValueError(
+                f"events.json metadata key {metadata_key!r} collides with BOLD "
+                f"identity entity — reserved keys: "
+                f"{sorted(_BOLD_IDENTITY_ENTITIES)}"
+            )
+
+    for record in segment_records:
+        for metadata_key in metadata_keys:
+            metadata_value = record[metadata_key]
+            if not isinstance(metadata_value, str) or not BIDS_ENTITY_VALUE_RE.match(
+                metadata_value
+            ):
+                raise ValueError(
+                    f"events.json metadata value {metadata_value!r} for key "
+                    f"{metadata_key!r} is invalid — values must be strings "
+                    f"matching {BIDS_ENTITY_VALUE_RE.pattern}"
+                )
+
+
+def load_bold_meta(bold_path: str | os.PathLike[str]) -> BoldMeta:
+    """Load all metadata for a BOLD run: TR, segments, and segment metadata.
+
+    Segment metadata is sourced from the colocated events.json `Segments` field
+    and merged into each `Segment.metadata`. If no events.json is present,
+    segments have empty metadata dicts.
+
+    Raises ValueError if events.tsv or events.json contents are invalid, or if
+    an events.json is present but no segments were parsed from events.tsv.
+    """
+    bold_path = Path(bold_path)
+    repetition_time = get_repetition_time(bold_path)
+    events = load_events_tsv(bold_path)
+    events_json = load_events_json(bold_path)
+
+    segments = _parse_segments(events, repetition_time)
+    segment_records: list[dict] = events_json.get("Segments", []) if events_json else []
+    if segment_records:
+        if not segments:
+            raise ValueError(
+                "events.json has a Segments field but events.tsv has no BIDS "
+                "key-value rows — add segment rows to events.tsv or remove Segments "
+                "from events.json"
+            )
+        _validate_segment_records(segment_records, segments)
+        segment_entity = segments[0].entity
+        metadata_by_segment_value = {
+            record[segment_entity]: {
+                k: v for k, v in record.items() if k != segment_entity
+            }
+            for record in segment_records
+        }
+        segments = [
+            replace(seg, metadata=metadata_by_segment_value[seg.value])
+            for seg in segments
+        ]
+
+    return BoldMeta(path=bold_path, repetition_time=repetition_time, segments=segments)

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -4,19 +4,17 @@ from pathlib import Path
 from typing import Iterator, NamedTuple
 
 import numpy as np
-import polars as pl
 from pydantic import BaseModel
 
 from hypline.bids import (
-    BIDS_ENTITY_RE,
     BIDSPath,
     validate_bids_entities,
     validate_entity_invariance,
 )
 from hypline.bold import (
     BOLD_EXTENSIONS,
-    get_repetition_time,
-    load_events,
+    BoldMeta,
+    load_bold_meta,
     parse_bold_space,
 )
 from hypline.enums import Device
@@ -90,17 +88,6 @@ class FeatureKey(NamedTuple):
     feature: str
 
 
-class Partitioning(NamedTuple):
-    entity: str
-    slices: dict[str, slice]  # entity value → TR-slice
-
-
-class BoldMeta(NamedTuple):
-    path: Path
-    repetition_time: float
-    partitioning: Partitioning | None
-
-
 class EncodingConfig(BaseModel):
     device: Device = Device.CPU
 
@@ -119,91 +106,6 @@ class TrainingData:
     Y: np.ndarray
     row_slices: dict[CellKey, slice]
     col_slices: dict[str, slice]
-
-
-def _tiles(slices: list[slice]) -> bool:
-    """Return True if slices start at 0, are non-overlapping, and are contiguous."""
-    ordered = sorted(slices, key=lambda s: s.start)
-    if ordered[0].start != 0:
-        return False
-    return all(a.stop == b.start for a, b in zip(ordered, ordered[1:]))
-
-
-def _mean_slice_duration(slices: dict[str, slice]) -> float:
-    return sum(s.stop - s.start for s in slices.values()) / len(slices)
-
-
-def _infer_partitioning(
-    events: pl.DataFrame | None,
-    repetition_time: float,
-) -> Partitioning | None:
-    """Identify the partition entity and its TR-slices from events.tsv.
-
-    Convention: BIDS key-value trial_type rows (e.g., `block-1`, `trial-A`)
-    declare partitions — non-overlapping time windows that tile the run.
-    Non-partition annotations must use flat (non-key-value) trial_type labels
-    (e.g., `rest`, `fixation`). Every BIDS key-value entity found in events must
-    tile the run; partial tiling is a design error and raises.
-
-    Tiling = values start at onset=0, are non-overlapping, contiguous, and cover the
-    full events span. The partition entity is the tiling entity with the smallest
-    average slice duration; ties raise.
-
-    Returns None when there are no BIDS key-value events (unpartitioned run).
-    """
-    if events is None:
-        return None
-
-    partition_rows = events.filter(
-        pl.col("trial_type").str.contains(BIDS_ENTITY_RE.pattern)
-        & (pl.col("duration") > 0.0)
-    )
-
-    if partition_rows.is_empty():
-        return None
-
-    slices_by_entity: dict[str, dict[str, slice]] = {}
-    for row in partition_rows.iter_rows(named=True):
-        entity_name, entity_value = row["trial_type"].split("-", 1)
-        onset_tr = round(row["onset"] / repetition_time)
-        n_trs = round(row["duration"] / repetition_time)
-        entity_slices = slices_by_entity.setdefault(entity_name, {})
-        entity_slices[entity_value] = slice(onset_tr, onset_tr + n_trs)
-
-    events_span_trs = round(
-        partition_rows.select((pl.col("onset") + pl.col("duration")).max()).item()
-        / repetition_time
-    )
-
-    tiling = {
-        entity_name: entity_slices
-        for entity_name, entity_slices in slices_by_entity.items()
-        if _tiles(list(entity_slices.values()))
-        and max(s.stop for s in entity_slices.values()) == events_span_trs
-    }
-
-    non_tiling = sorted(slices_by_entity.keys() - tiling.keys())
-    if non_tiling:
-        raise ValueError(
-            f"BIDS entities {non_tiling} in events.tsv do not partition the run "
-            f"cleanly. Values must be unique and slices must cover the run "
-            f"contiguously from onset 0. Check for duplicate values (e.g. trial IDs "
-            f"reset per block), gaps, overlaps, or partial run coverage. Use flat "
-            f"trial_type labels (e.g. 'rest') for non-partition annotations."
-        )
-
-    # Partition entity is the tiling entity with the finest granularity
-    avg_durations = {name: _mean_slice_duration(s) for name, s in tiling.items()}
-    min_avg = min(avg_durations.values())
-    tied = [name for name, avg in avg_durations.items() if avg == min_avg]
-    if len(tied) > 1:
-        raise ValueError(
-            f"entities {tied[0]!r} and {tied[1]!r} both tile the run at identical "
-            f"granularity — remove the redundant one"
-        )
-    partition_entity = tied[0]
-
-    return Partitioning(entity=partition_entity, slices=tiling[partition_entity])
 
 
 def _format_loc(**entities: str | None) -> str:
@@ -393,11 +295,10 @@ class Encoding:
         """Discover BOLD files and load their metadata for a subject.
 
         Scans the BOLD directory by filename without loading image arrays. TR is
-        read from the sidecar JSON, falling back to the image header. Partitioning
-        is inferred from the colocated events TSV when present — raises if events
-        contain BIDS entities that fail to tile the run. All runs are guaranteed to
-        share the same TR, BOLD-level entity invariants, and partition entity (or all
-        unpartitioned).
+        read from the sidecar JSON, falling back to the image header. Segmentation
+        is inferred from the colocated events TSV when present. All runs are guaranteed
+        to share the same TR, BOLD-level entity invariants, and segment entity (or all
+        unsegmented).
         """
 
         bold_ext = BOLD_EXTENSIONS[type(self.bold_space)]
@@ -435,18 +336,11 @@ class Encoding:
                     f"Duplicate BOLD file at {loc}:\n"
                     f"  {bold_metas[bold_key].path}\n  {bold_file}"
                 )
-            repetition_time = get_repetition_time(bold_file)
-            events = load_events(bold_file)
             try:
-                partitioning = _infer_partitioning(events, repetition_time)
+                bold_metas[bold_key] = load_bold_meta(bold_file)
             except ValueError as e:
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
                 raise ValueError(f"{e} for {loc}") from e
-            bold_metas[bold_key] = BoldMeta(
-                path=bold_file,
-                repetition_time=repetition_time,
-                partitioning=partitioning,
-            )
 
         # Validate: acquisition entities are invariant across all runs
         bold_bids = [BIDSPath(meta.path) for meta in bold_metas.values()]
@@ -463,20 +357,36 @@ class Encoding:
                 f"subject {sub_id}: {repetition_times}"
             )
 
-        # Validate: partition entity is invariant across all runs (or all unpartitioned)
-        partition_entities = {
-            meta.partitioning.entity if meta.partitioning is not None else None
+        # Validate: segment entity is invariant across all runs (or all unsegmented)
+        segment_entities = {
+            meta.segments[0].entity if meta.segments else None
             for meta in bold_metas.values()
         }
-        if len(partition_entities) > 1:
+        if len(segment_entities) > 1:
             run_labels = sorted(
                 f"{meta.path.name} ("
-                f"{meta.partitioning.entity if meta.partitioning else 'unpartitioned'})"
+                f"{meta.segments[0].entity if meta.segments else 'unsegmented'})"
                 for meta in bold_metas.values()
             )
             raise ValueError(
-                f"BOLD runs disagree on partition entity for subject {sub_id}:\n  "
+                f"BOLD runs disagree on segment entity for subject {sub_id}:\n  "
                 + "\n  ".join(run_labels)
+            )
+
+        # Validate: segment metadata schema is invariant across segmented runs
+        segmented_metas = [meta for meta in bold_metas.values() if meta.segments]
+        metadata_key_sets = {
+            frozenset(seg.metadata) for meta in segmented_metas for seg in meta.segments
+        }
+        if len(metadata_key_sets) > 1:
+            run_labels = sorted(
+                f"{meta.path.name} "
+                f"({sorted(meta.segments[0].metadata) or 'no metadata'})"
+                for meta in segmented_metas
+            )
+            raise ValueError(
+                f"BOLD runs disagree on segment metadata schema for subject "
+                f"{sub_id}:\n  " + "\n  ".join(run_labels)
             )
 
         return bold_metas
@@ -490,15 +400,15 @@ class Encoding:
 
         Checks sub/task invariance across all files, bidirectional ses/run coverage
         between features and BOLD, and that feature cells align with each run's
-        partitioning: for partitioned runs, every cell must carry the partition entity
-        with a value declared in events; for unpartitioned runs, exactly one cell per
+        segmentation: for segmented runs, every cell must carry the segment entity
+        with a value declared in events; for unsegmented runs, exactly one cell per
         run is allowed.
 
         Notes
         -----
-        When all BOLD runs are unpartitioned, extra entities on feature filenames
+        When all BOLD runs are unsegmented, extra entities on feature filenames
         beyond ses/run are accepted as descriptive tags. If those entities were intended
-        as partition keys but events.tsv is absent or contains no BIDS key-value rows,
+        as segment keys but events.tsv is absent or contains no BIDS key-value rows,
         the misalignment is not detectable here and will surface only as unexpected
         row counts in the assembled X/Y matrices.
         """
@@ -534,7 +444,7 @@ class Encoding:
                 msg += f" ({len(features_without_bold) - 1} other coverage gaps exist)"
             raise FileNotFoundError(msg)
 
-        # Validate feature cells against each run's partitioning
+        # Validate feature cells against each run's segmentation
         cells_by_bold_key: dict[BoldKey, list[CellKey]] = {}
         for cell_key in cell_keys:
             bold_key = BoldKey(cell_key.get("ses"), cell_key.get("run"))
@@ -544,27 +454,27 @@ class Encoding:
             run_cells = cells_by_bold_key[bold_key]
             loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
 
-            if bold_meta.partitioning is None:
+            if not bold_meta.segments:
                 if len(run_cells) > 1:
                     raise ValueError(
-                        f"Run is unpartitioned but has {len(run_cells)} feature cells "
-                        f"at {loc} — provide an events.tsv with tiling entities to "
-                        f"partition the run"
+                        f"Run is unsegmented but has {len(run_cells)} feature cells "
+                        f"at {loc} — provide an events.tsv with BIDS key-value "
+                        f"entities to segment the run"
                     )
             else:
-                entity = bold_meta.partitioning.entity
+                entity = bold_meta.segments[0].entity
+                segment_values = {seg.value for seg in bold_meta.segments}
                 for cell_key in run_cells:
                     value = cell_key.get(entity)
                     if value is None:
                         raise ValueError(
-                            f"Feature cell {cell_key!r} at {loc} is missing partition "
+                            f"Feature cell {cell_key!r} at {loc} is missing segment "
                             f"entity {entity!r} declared in events"
                         )
-                    if value not in bold_meta.partitioning.slices:
+                    if value not in segment_values:
                         raise ValueError(
-                            f"Partition value {entity}-{value} at {loc} not found in "
-                            f"events — valid values: "
-                            f"{sorted(bold_meta.partitioning.slices)}"
+                            f"Segment value {entity}-{value} at {loc} not found in "
+                            f"events — valid values: {sorted(segment_values)}"
                         )
 
     def _build_xy(
@@ -578,7 +488,7 @@ class Encoding:
         across runs. Column layout is derived from the first cell and assumed
         invariant — all cells must yield the same feature dimensionality.
 
-        Partition slice coverage is validated against actual BOLD array length before
+        Segment slice coverage is validated against actual BOLD array length before
         any data is assembled; a mismatch raises early rather than producing a
         silently truncated Y.
         """
@@ -587,17 +497,17 @@ class Encoding:
         }
 
         for bold_key, bold_meta in bold_metas.items():
-            if bold_meta.partitioning is None:
+            if not bold_meta.segments:
                 continue
-            expected = max(s.stop for s in bold_meta.partitioning.slices.values())
+            expected = max(seg.slice.stop for seg in bold_meta.segments)
             actual = bold_arrays[bold_key].shape[0]
-            if expected != actual:
+            if expected > actual:
                 first_bold = next(iter(bold_metas.values()))
                 sub_id = BIDSPath(first_bold.path).entities.get("sub")
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
                 raise ValueError(
-                    f"Partition slices cover {expected} TRs "
-                    f"but BOLD has {actual} for {loc}"
+                    f"Segment slices extend to TR {expected} "
+                    f"but BOLD has only {actual} TRs for {loc}"
                 )
 
         # None sorts before any value; empty string is a stable tiebreaker for ses/run
@@ -625,12 +535,13 @@ class Encoding:
             bold_data = bold_arrays[bold_key]
 
             # Construct Y for the given cell
-            if bold_meta.partitioning is None:
+            if not bold_meta.segments:
                 onset_tr, n_trs = 0, bold_data.shape[0]
             else:
-                partition_value = cell_key[bold_meta.partitioning.entity]
-                tr_slice = bold_meta.partitioning.slices[partition_value]
-                onset_tr, n_trs = tr_slice.start, tr_slice.stop - tr_slice.start
+                segment_entity = bold_meta.segments[0].entity
+                segment_value = cell_key[segment_entity]
+                seg = next(s for s in bold_meta.segments if s.value == segment_value)
+                onset_tr, n_trs = seg.slice.start, seg.slice.stop - seg.slice.start
             row_slices[cell_key] = slice(row_offset, row_offset + n_trs)
             row_offset += n_trs
             Y_parts.append(bold_data[onset_tr : onset_tr + n_trs])

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -24,17 +24,6 @@ from hypline.utils import find_files, validate_dirs
 # Entities provided via dedicated arguments — not allowed in bids_filters
 _RESERVED_ENTITIES = frozenset(("sub", "space", "feature"))
 
-# Entities valid for filtering both feature and BOLD files
-_COMMON_FILTER_ENTITIES = frozenset(("ses", "task", "run"))
-
-# Entities valid for BOLD files only — stripped from feature-side filters
-_BOLD_EXCLUSIVE_ENTITIES = frozenset(
-    ("desc", "res", "den", "echo", "acq", "ce", "rec", "dir")
-)
-
-# Entities valid for BOLD file filtering — union of common and BOLD-exclusive
-_BOLD_FILTER_ENTITIES = _COMMON_FILTER_ENTITIES | _BOLD_EXCLUSIVE_ENTITIES
-
 
 class BoldKey(NamedTuple):
     ses: str | None
@@ -44,12 +33,30 @@ class BoldKey(NamedTuple):
 class CellKey:
     """Open-schema key identifying a single feature time window.
 
-    Entities in EXCLUDE are rejected — they are invariant within a training call
-    (sub, task), belong to a different axis (feature), or are BOLD-only (space).
+    EXCLUDE defines which entities must never appear on a cell key:
+    - sub, task, acq, ce, rec, dir: invariant across a training call
+    - desc, res, den, echo: image-variant entities (BOLD derivatives only)
+    - space, feature: orthogonal axes — handled by dedicated arguments
+
     Equality and hashing are order-independent.
     """
 
-    EXCLUDE: frozenset[str] = frozenset(("sub", "task", "space", "feature"))
+    EXCLUDE: frozenset[str] = frozenset(
+        (
+            "sub",
+            "task",
+            "acq",
+            "ce",
+            "rec",
+            "dir",
+            "desc",
+            "res",
+            "den",
+            "echo",
+            "space",
+            "feature",
+        )
+    )
     __slots__ = ("_entities",)
 
     def __init__(self, **entities: str) -> None:
@@ -175,7 +182,9 @@ class Encoding:
     def train(self, sub_id: str):
         feature_paths = self._discover_features(sub_id)
         bold_metas = self._discover_bold(sub_id)
-        self._validate_alignment(feature_paths, bold_metas)
+        feature_paths = self._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = self._apply_filters(feature_paths, bold_metas)
+        self._validate_coverage(feature_paths, bold_metas)
         data = self._build_xy(feature_paths, bold_metas)
 
         # TODO: modeling (banded ridge regression) goes here
@@ -185,53 +194,24 @@ class Encoding:
         """Discover and validate feature file paths for a subject.
 
         Scans the features directory by BIDS filename alone — no feature data is read.
-        bids_filters are routed to find_files after stripping BOLD-exclusive entities.
-        Duplicate files for the same (cell, feature) pair raise immediately.
+        Only sub and feature are used to filter find_files; bids_filters are applied
+        post-enrichment in _apply_filters. Duplicate files for the same (cell, feature)
+        pair raise immediately.
 
         Returns a flat dict mapping each (cell, feature) pair to its path.
         Every cell is guaranteed to have all requested features — a missing feature
         at any cell raises rather than silently producing an incomplete matrix.
         All files are guaranteed to share the same cell schema (entity key set).
-        A filter entity absent from all discovered files raises ValueError before
-        FileNotFoundError — catches typos and mismatched filter entities early.
         """
-        feature_filters = [
-            entity
-            for entity in self.bids_filters
-            if entity.split("-", 1)[0] not in _BOLD_EXCLUSIVE_ENTITIES
-        ]
-
         feature_paths: dict[FeatureKey, Path] = {}
         for feature_name in self.features:
             feature_files = find_files(
                 self.features_dir,
                 ends_with=".parquet",
                 recursive=True,
-                bids_filters=[
-                    f"sub-{sub_id}",
-                    f"feature-{feature_name}",
-                    *feature_filters,
-                ],
+                bids_filters=[f"sub-{sub_id}", f"feature-{feature_name}"],
             )
             if not feature_files:
-                # Check whether a filter entity typo caused the empty result
-                unfiltered = find_files(
-                    self.features_dir,
-                    ends_with=".parquet",
-                    recursive=True,
-                    bids_filters=[f"sub-{sub_id}", f"feature-{feature_name}"],
-                )
-                if unfiltered:
-                    unfiltered_schema = frozenset(
-                        key for path in unfiltered for key in BIDSPath(path).entities
-                    )
-                    for entity in feature_filters:
-                        key = entity.split("-", 1)[0]
-                        if key not in unfiltered_schema:
-                            raise ValueError(
-                                f"bids_filters entity {key!r} not found on any "
-                                f"feature={feature_name} file for sub={sub_id}"
-                            )
                 raise FileNotFoundError(
                     f"No matching feature files found for sub={sub_id}, "
                     f"feature={feature_name} in {self.features_dir}"
@@ -300,22 +280,12 @@ class Encoding:
         to share the same TR, BOLD-level entity invariants, and segment entity (or all
         unsegmented).
         """
-
         bold_ext = BOLD_EXTENSIONS[type(self.bold_space)]
-        bold_filters = [
-            f"sub-{sub_id}",
-            f"space-{self.bold_space}",
-            *(
-                entity
-                for entity in self.bids_filters
-                if entity.split("-", 1)[0] in _BOLD_FILTER_ENTITIES
-            ),
-        ]
         bold_files = find_files(
             self.bold_dir,
             ends_with=f"_bold{bold_ext}",
             recursive=True,
-            bids_filters=bold_filters,
+            bids_filters=[f"sub-{sub_id}", f"space-{self.bold_space}"],
         )
         if not bold_files:
             raise FileNotFoundError(
@@ -334,7 +304,7 @@ class Encoding:
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
                 raise ValueError(
                     f"Duplicate BOLD file at {loc}:\n"
-                    f"  {bold_metas[bold_key].path}\n  {bold_file}"
+                    f"  {bold_metas[bold_key].bids.path}\n  {bold_file}"
                 )
             try:
                 bold_metas[bold_key] = load_bold_meta(bold_file)
@@ -343,7 +313,7 @@ class Encoding:
                 raise ValueError(f"{e} for {loc}") from e
 
         # Validate: acquisition entities are invariant across all runs
-        bold_bids = [BIDSPath(meta.path) for meta in bold_metas.values()]
+        bold_bids = [meta.bids for meta in bold_metas.values()]
         try:
             validate_entity_invariance(bold_bids, ("task", "acq", "ce", "rec", "dir"))
         except ValueError as e:
@@ -364,7 +334,7 @@ class Encoding:
         }
         if len(segment_entities) > 1:
             run_labels = sorted(
-                f"{meta.path.name} ("
+                f"{meta.bids.path.name} ("
                 f"{meta.segments[0].entity if meta.segments else 'unsegmented'})"
                 for meta in bold_metas.values()
             )
@@ -380,7 +350,7 @@ class Encoding:
         }
         if len(metadata_key_sets) > 1:
             run_labels = sorted(
-                f"{meta.path.name} "
+                f"{meta.bids.path.name} "
                 f"({sorted(meta.segments[0].metadata) or 'no metadata'})"
                 for meta in segmented_metas
             )
@@ -391,91 +361,234 @@ class Encoding:
 
         return bold_metas
 
-    def _validate_alignment(
+    def _resolve_cell_keys(
+        self,
+        feature_paths: dict[FeatureKey, Path],
+        bold_metas: dict[BoldKey, BoldMeta],
+    ) -> dict[FeatureKey, Path]:
+        """Validate and resolve feature CellKeys against BOLD segment metadata.
+
+        For each feature cell, locates the matching BOLD run and segment, then
+        merges segment.metadata into the CellKey. Filename entities beyond ses, run,
+        and the segment entity are rejected unless they echo a metadata key from
+        events.json — descriptive metadata must live in events.json, not filenames.
+
+        Invariant: _discover_bold guarantees all segments share the same metadata
+        schema across runs, so resolved cells always end up with a uniform key set.
+        """
+        cell_keys_by_bold_key: dict[BoldKey, set[CellKey]] = {}
+        for feature_key in feature_paths:
+            bold_key = BoldKey(feature_key.cell.get("ses"), feature_key.cell.get("run"))
+            cell_keys_by_bold_key.setdefault(bold_key, set()).add(feature_key.cell)
+
+        orphan_bold_keys = cell_keys_by_bold_key.keys() - bold_metas.keys()
+        if orphan_bold_keys:
+            bold_key = next(iter(orphan_bold_keys))
+            loc = _format_loc(
+                ses=bold_key.ses, run=bold_key.run, space=str(self.bold_space)
+            )
+            msg = f"No BOLD file found for features at {loc}"
+            if len(orphan_bold_keys) > 1:
+                msg += f" ({len(orphan_bold_keys) - 1} other coverage gaps exist)"
+            raise FileNotFoundError(msg)
+
+        resolved_feature_paths: dict[FeatureKey, Path] = {}
+        for feature_key, path in feature_paths.items():
+            cell_key = feature_key.cell
+            bold_key = BoldKey(cell_key.get("ses"), cell_key.get("run"))
+            bold_meta = bold_metas[bold_key]
+
+            if not bold_meta.segments:
+                run_cell_keys = cell_keys_by_bold_key[bold_key]
+                if len(run_cell_keys) > 1:
+                    loc = _format_loc(ses=bold_key.ses, run=bold_key.run)
+                    raise ValueError(
+                        f"Run is unsegmented but has {len(run_cell_keys)} feature "
+                        f"cells at {loc} — provide an events.tsv with BIDS key-value "
+                        f"entities to segment the run"
+                    )
+                illegal_keys = cell_key.keys() - {"ses", "run"}
+                if illegal_keys:
+                    raise ValueError(
+                        f"Feature cell {cell_key!r} carries entities "
+                        f"{sorted(illegal_keys)} that do not identify the run. "
+                        f"For an unsegmented run, only ses and run are valid on "
+                        f"feature filenames — move descriptive metadata to events.json"
+                    )
+                resolved_feature_paths[feature_key] = path
+                continue
+
+            segment_entity = bold_meta.segments[0].entity
+            segment_values = {segment.value for segment in bold_meta.segments}
+
+            # Validate the cell carries a known segment value for this run
+            segment_value = cell_key.get(segment_entity)
+            if segment_value is None:
+                loc = _format_loc(ses=bold_key.ses, run=bold_key.run)
+                raise ValueError(
+                    f"Feature cell {cell_key!r} at {loc} is missing segment "
+                    f"entity {segment_entity!r} declared in events"
+                )
+            if segment_value not in segment_values:
+                loc = _format_loc(ses=bold_key.ses, run=bold_key.run)
+                raise ValueError(
+                    f"Segment value {segment_entity}-{segment_value} at {loc} not "
+                    f"found in events — valid values: {sorted(segment_values)}"
+                )
+
+            segment = next(
+                seg for seg in bold_meta.segments if seg.value == segment_value
+            )
+
+            # Reject filename entities that are not run-locating, segment, or metadata
+            legal_keys = {"ses", "run"} | {segment_entity} | segment.metadata.keys()
+            illegal_keys = cell_key.keys() - legal_keys
+            if illegal_keys:
+                raise ValueError(
+                    f"Feature cell {cell_key!r} carries entities "
+                    f"{sorted(illegal_keys)} that are absent from events.json "
+                    f"metadata. Descriptive attributes must live in events.json, "
+                    f"not feature filenames"
+                )
+
+            # Merge metadata: filename value takes precedence only if it agrees
+            extra_metadata: dict[str, str] = {}
+            for entity, value in segment.metadata.items():
+                if cell_key.get(entity) is not None and cell_key[entity] != value:
+                    raise ValueError(
+                        f"Feature filename and events.json disagree on {entity!r} "
+                        f"for {segment_entity}-{segment_value}: "
+                        f"filename has {cell_key[entity]!r}, sidecar has {value!r}"
+                    )
+                if cell_key.get(entity) is None:
+                    extra_metadata[entity] = value
+            if extra_metadata:
+                resolved_cell_key = CellKey(
+                    **{**dict(cell_key.items()), **extra_metadata}
+                )
+                resolved_feature_paths[
+                    FeatureKey(cell=resolved_cell_key, feature=feature_key.feature)
+                ] = path
+            else:
+                resolved_feature_paths[feature_key] = path
+
+        return resolved_feature_paths
+
+    def _apply_filters(
+        self,
+        feature_paths: dict[FeatureKey, Path],
+        bold_metas: dict[BoldKey, BoldMeta],
+    ) -> tuple[dict[FeatureKey, Path], dict[BoldKey, BoldMeta]]:
+        """Apply bids_filters to feature cells and BOLD runs.
+
+        Filters are applied against CellKey entities for features, and against
+        filename entities for BOLD. Same-entity filter values OR-match within a
+        group; different entities AND-match across groups. A filter key absent from
+        one side is skipped on that side rather than rejecting all rows. A filter
+        key absent from both sides raises ValueError (typo diagnostic) before any
+        empty-result condition surfaces as a coverage error.
+        """
+        if not self.bids_filters:
+            return feature_paths, bold_metas
+
+        # Group filter values by entity for matching later
+        allowed_values_by_entity: dict[str, list[str]] = {}
+        for bids_filter in self.bids_filters:
+            entity_key, entity_value = bids_filter.split("-", 1)
+            allowed_values_by_entity.setdefault(entity_key, []).append(entity_value)
+
+        # Collect entity key schema from both sides for typo detection
+        cell_entity_keys = frozenset(
+            entity_key
+            for feature_key in feature_paths
+            for entity_key in feature_key.cell.keys()
+        )
+        bold_entity_keys = frozenset(
+            entity_key
+            for meta in bold_metas.values()
+            for entity_key in meta.bids.entities
+        )
+        known_entity_keys = cell_entity_keys | bold_entity_keys
+
+        for entity_key in allowed_values_by_entity:
+            if entity_key not in known_entity_keys:
+                raise ValueError(
+                    f"bids_filters entity {entity_key!r} not found on any "
+                    f"feature cell or BOLD file for this subject — check for a typo"
+                )
+
+        def _cell_matches(cell: CellKey) -> bool:
+            return all(
+                cell.get(entity_key) in entity_values
+                for entity_key, entity_values in allowed_values_by_entity.items()
+                if entity_key in cell_entity_keys
+            )
+
+        def _bold_matches(bids: BIDSPath) -> bool:
+            return all(
+                bids.entities.get(entity_key) in entity_values
+                for entity_key, entity_values in allowed_values_by_entity.items()
+                if entity_key in bold_entity_keys
+            )
+
+        filtered_features = {
+            feature_key: path
+            for feature_key, path in feature_paths.items()
+            if _cell_matches(feature_key.cell)
+        }
+        filtered_bold = {
+            bold_key: meta
+            for bold_key, meta in bold_metas.items()
+            if _bold_matches(meta.bids)
+        }
+
+        return filtered_features, filtered_bold
+
+    def _validate_coverage(
         self,
         feature_paths: dict[FeatureKey, Path],
         bold_metas: dict[BoldKey, BoldMeta],
     ) -> None:
-        """Validate that feature and BOLD files are mutually consistent.
+        """Validate bidirectional ses/run coverage between filtered features and BOLD.
 
-        Checks sub/task invariance across all files, bidirectional ses/run coverage
-        between features and BOLD, and that feature cells align with each run's
-        segmentation: for segmented runs, every cell must carry the segment entity
-        with a value declared in events; for unsegmented runs, exactly one cell per
-        run is allowed.
-
-        Notes
-        -----
-        When all BOLD runs are unsegmented, extra entities on feature filenames
-        beyond ses/run are accepted as descriptive tags. If those entities were intended
-        as segment keys but events.tsv is absent or contains no BIDS key-value rows,
-        the misalignment is not detectable here and will surface only as unexpected
-        row counts in the assembled X/Y matrices.
+        Also checks sub/task invariance across all feature and BOLD files.
+        Raises if either side is empty — indicates filters selected nothing.
         """
+        if not feature_paths:
+            raise FileNotFoundError("No feature files match the given filters")
+        if not bold_metas:
+            raise FileNotFoundError("No BOLD files match the given filters")
+
         feature_bids = [BIDSPath(path) for path in feature_paths.values()]
-        bold_bids = [BIDSPath(meta.path) for meta in bold_metas.values()]
+        bold_bids = [meta.bids for meta in bold_metas.values()]
         sub_id = (feature_bids or bold_bids)[0].entities.get("sub")
         try:
             validate_entity_invariance(feature_bids + bold_bids, ("sub", "task"))
         except ValueError as e:
             raise ValueError(f"{e} (subject {sub_id})") from e
 
-        # Every BOLD file must have feature coverage
         cell_keys = {feature_key.cell for feature_key in feature_paths}
         covered_bold_keys = {
             BoldKey(key.get("ses"), key.get("run")) for key in cell_keys
         }
+
         bold_without_features = bold_metas.keys() - covered_bold_keys
         if bold_without_features:
             bold_key = next(iter(bold_without_features))
             loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
-            msg = f"No feature files found for BOLD at {loc or f'sub={sub_id}'}"
+            msg = f"No feature files found for BOLD at {loc}"
             if len(bold_without_features) > 1:
                 msg += f" ({len(bold_without_features) - 1} other coverage gaps exist)"
             raise FileNotFoundError(msg)
 
-        # Every feature file must have a matching BOLD file
         features_without_bold = covered_bold_keys - bold_metas.keys()
         if features_without_bold:
             bold_key = next(iter(features_without_bold))
             loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
-            msg = f"No BOLD file found for features at {loc or f'sub={sub_id}'}"
+            msg = f"No BOLD file found for features at {loc}"
             if len(features_without_bold) > 1:
                 msg += f" ({len(features_without_bold) - 1} other coverage gaps exist)"
             raise FileNotFoundError(msg)
-
-        # Validate feature cells against each run's segmentation
-        cells_by_bold_key: dict[BoldKey, list[CellKey]] = {}
-        for cell_key in cell_keys:
-            bold_key = BoldKey(cell_key.get("ses"), cell_key.get("run"))
-            cells_by_bold_key.setdefault(bold_key, []).append(cell_key)
-
-        for bold_key, bold_meta in bold_metas.items():
-            run_cells = cells_by_bold_key[bold_key]
-            loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
-
-            if not bold_meta.segments:
-                if len(run_cells) > 1:
-                    raise ValueError(
-                        f"Run is unsegmented but has {len(run_cells)} feature cells "
-                        f"at {loc} — provide an events.tsv with BIDS key-value "
-                        f"entities to segment the run"
-                    )
-            else:
-                entity = bold_meta.segments[0].entity
-                segment_values = {seg.value for seg in bold_meta.segments}
-                for cell_key in run_cells:
-                    value = cell_key.get(entity)
-                    if value is None:
-                        raise ValueError(
-                            f"Feature cell {cell_key!r} at {loc} is missing segment "
-                            f"entity {entity!r} declared in events"
-                        )
-                    if value not in segment_values:
-                        raise ValueError(
-                            f"Segment value {entity}-{value} at {loc} not found in "
-                            f"events — valid values: {sorted(segment_values)}"
-                        )
 
     def _build_xy(
         self,
@@ -493,7 +606,7 @@ class Encoding:
         silently truncated Y.
         """
         bold_arrays: dict[BoldKey, np.ndarray] = {
-            key: _load_bold_array(meta.path) for key, meta in bold_metas.items()
+            key: _load_bold_array(meta.bids.path) for key, meta in bold_metas.items()
         }
 
         for bold_key, bold_meta in bold_metas.items():
@@ -503,7 +616,7 @@ class Encoding:
             actual = bold_arrays[bold_key].shape[0]
             if expected > actual:
                 first_bold = next(iter(bold_metas.values()))
-                sub_id = BIDSPath(first_bold.path).entities.get("sub")
+                sub_id = first_bold.bids.entities.get("sub")
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
                 raise ValueError(
                     f"Segment slices extend to TR {expected} "

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -182,10 +182,12 @@ class Encoding:
     def train(self, sub_id: str):
         feature_paths = self._discover_features(sub_id)
         bold_metas = self._discover_bold(sub_id)
-        feature_paths = self._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = self._apply_filters(feature_paths, bold_metas)
-        self._validate_coverage(feature_paths, bold_metas)
-        data = self._build_xy(feature_paths, bold_metas)
+        feature_paths = self._resolve_cell_keys(sub_id, feature_paths, bold_metas)
+        feature_paths, bold_metas = self._apply_filters(
+            sub_id, feature_paths, bold_metas
+        )
+        self._validate_coverage(sub_id, feature_paths, bold_metas)
+        data = self._build_xy(sub_id, feature_paths, bold_metas)
 
         # TODO: modeling (banded ridge regression) goes here
         data
@@ -310,7 +312,7 @@ class Encoding:
                 bold_metas[bold_key] = load_bold_meta(bold_file)
             except ValueError as e:
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
-                raise ValueError(f"{e} for {loc}") from e
+                raise ValueError(f"Failed to load BOLD at {loc}: {e}") from e
 
         # Validate: acquisition entities are invariant across all runs
         bold_bids = [meta.bids for meta in bold_metas.values()]
@@ -363,6 +365,7 @@ class Encoding:
 
     def _resolve_cell_keys(
         self,
+        sub_id: str,
         feature_paths: dict[FeatureKey, Path],
         bold_metas: dict[BoldKey, BoldMeta],
     ) -> dict[FeatureKey, Path]:
@@ -385,7 +388,10 @@ class Encoding:
         if orphan_bold_keys:
             bold_key = next(iter(orphan_bold_keys))
             loc = _format_loc(
-                ses=bold_key.ses, run=bold_key.run, space=str(self.bold_space)
+                sub=sub_id,
+                ses=bold_key.ses,
+                run=bold_key.run,
+                space=self.bold_space,
             )
             msg = f"No BOLD file found for features at {loc}"
             if len(orphan_bold_keys) > 1:
@@ -401,20 +407,31 @@ class Encoding:
             if not bold_meta.segments:
                 run_cell_keys = cell_keys_by_bold_key[bold_key]
                 if len(run_cell_keys) > 1:
-                    loc = _format_loc(ses=bold_key.ses, run=bold_key.run)
+                    loc = _format_loc(
+                        sub=sub_id,
+                        ses=bold_key.ses,
+                        run=bold_key.run,
+                        space=self.bold_space,
+                    )
                     raise ValueError(
                         f"Run is unsegmented but has {len(run_cell_keys)} feature "
-                        f"cells at {loc} — provide an events.tsv with BIDS key-value "
+                        f"files at {loc} — provide an events.tsv with BIDS key-value "
                         f"entities to segment the run"
                     )
                 illegal_keys = cell_key.keys() - {"ses", "run"}
                 if illegal_keys:
+                    loc = _format_loc(
+                        sub=sub_id,
+                        ses=bold_key.ses,
+                        run=bold_key.run,
+                        space=self.bold_space,
+                    )
                     raise ValueError(
-                        f"Feature cell {cell_key!r} carries entities "
-                        f"{sorted(illegal_keys)} that do not identify the run. "
-                        f"For an unsegmented run, only ses and run are valid on "
-                        f"feature filenames. To attach metadata, declare a segment "
-                        f"row in events.tsv and add descriptive attributes to "
+                        f"Unsegmented run at {loc} has feature filename with "
+                        f"unexpected entities {sorted(illegal_keys)} — only ses "
+                        f"and run are valid on feature filenames for unsegmented "
+                        f"runs. To attach metadata, declare a segment row in "
+                        f"events.tsv and add descriptive attributes to "
                         f"events.json SegmentMetadata."
                     )
                 resolved_feature_paths[feature_key] = path
@@ -426,13 +443,23 @@ class Encoding:
             # Validate the cell carries a known segment value for this run
             segment_value = cell_key.get(segment_entity)
             if segment_value is None:
-                loc = _format_loc(ses=bold_key.ses, run=bold_key.run)
+                loc = _format_loc(
+                    sub=sub_id,
+                    ses=bold_key.ses,
+                    run=bold_key.run,
+                    space=self.bold_space,
+                )
                 raise ValueError(
-                    f"Feature cell {cell_key!r} at {loc} is missing segment "
-                    f"entity {segment_entity!r} declared in events"
+                    f"Feature filename at {loc} is missing segment entity "
+                    f"{segment_entity!r} declared in events"
                 )
             if segment_value not in segment_values:
-                loc = _format_loc(ses=bold_key.ses, run=bold_key.run)
+                loc = _format_loc(
+                    sub=sub_id,
+                    ses=bold_key.ses,
+                    run=bold_key.run,
+                    space=self.bold_space,
+                )
                 raise ValueError(
                     f"Segment value {segment_entity}-{segment_value} at {loc} not "
                     f"found in events — valid values: {sorted(segment_values)}"
@@ -446,20 +473,32 @@ class Encoding:
             legal_keys = {"ses", "run"} | {segment_entity} | segment.metadata.keys()
             illegal_keys = cell_key.keys() - legal_keys
             if illegal_keys:
+                loc = _format_loc(
+                    sub=sub_id,
+                    ses=bold_key.ses,
+                    run=bold_key.run,
+                    space=self.bold_space,
+                )
                 raise ValueError(
-                    f"Feature cell {cell_key!r} carries entities "
-                    f"{sorted(illegal_keys)} that are absent from events.json "
-                    f"metadata. Descriptive attributes must live in events.json, "
-                    f"not feature filenames"
+                    f"Feature filename at {loc} carries entities "
+                    f"{sorted(illegal_keys)} absent from events.json "
+                    f"metadata — descriptive attributes must live in "
+                    f"events.json, not feature filenames"
                 )
 
             # Merge metadata: filename value takes precedence only if it agrees
             extra_metadata: dict[str, str] = {}
             for entity, value in segment.metadata.items():
                 if cell_key.get(entity) is not None and cell_key[entity] != value:
+                    loc = _format_loc(
+                        sub=sub_id,
+                        ses=bold_key.ses,
+                        run=bold_key.run,
+                        space=self.bold_space,
+                    )
                     raise ValueError(
                         f"Feature filename and events.json disagree on {entity!r} "
-                        f"for {segment_entity}-{segment_value}: "
+                        f"at {loc} for {segment_entity}-{segment_value}: "
                         f"filename has {cell_key[entity]!r}, sidecar has {value!r}"
                     )
                 if cell_key.get(entity) is None:
@@ -478,6 +517,7 @@ class Encoding:
 
     def _apply_filters(
         self,
+        sub_id: str,
         feature_paths: dict[FeatureKey, Path],
         bold_metas: dict[BoldKey, BoldMeta],
     ) -> tuple[dict[FeatureKey, Path], dict[BoldKey, BoldMeta]]:
@@ -516,7 +556,7 @@ class Encoding:
             if entity_key not in known_entity_keys:
                 raise ValueError(
                     f"bids_filters entity {entity_key!r} not found on any "
-                    f"feature cell or BOLD file for this subject — check for a typo"
+                    f"feature cell or BOLD file for sub={sub_id} — check for a typo"
                 )
 
         def _cell_matches(cell: CellKey) -> bool:
@@ -548,6 +588,7 @@ class Encoding:
 
     def _validate_coverage(
         self,
+        sub_id: str,
         feature_paths: dict[FeatureKey, Path],
         bold_metas: dict[BoldKey, BoldMeta],
     ) -> None:
@@ -563,7 +604,6 @@ class Encoding:
 
         feature_bids = [BIDSPath(path) for path in feature_paths.values()]
         bold_bids = [meta.bids for meta in bold_metas.values()]
-        sub_id = (feature_bids or bold_bids)[0].entities.get("sub")
         try:
             validate_entity_invariance(feature_bids + bold_bids, ("sub", "task"))
         except ValueError as e:
@@ -577,7 +617,12 @@ class Encoding:
         bold_without_features = bold_metas.keys() - covered_bold_keys
         if bold_without_features:
             bold_key = next(iter(bold_without_features))
-            loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
+            loc = _format_loc(
+                sub=sub_id,
+                ses=bold_key.ses,
+                run=bold_key.run,
+                space=self.bold_space,
+            )
             msg = f"No feature files found for BOLD at {loc}"
             if len(bold_without_features) > 1:
                 msg += f" ({len(bold_without_features) - 1} other coverage gaps exist)"
@@ -586,7 +631,12 @@ class Encoding:
         features_without_bold = covered_bold_keys - bold_metas.keys()
         if features_without_bold:
             bold_key = next(iter(features_without_bold))
-            loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
+            loc = _format_loc(
+                sub=sub_id,
+                ses=bold_key.ses,
+                run=bold_key.run,
+                space=self.bold_space,
+            )
             msg = f"No BOLD file found for features at {loc}"
             if len(features_without_bold) > 1:
                 msg += f" ({len(features_without_bold) - 1} other coverage gaps exist)"
@@ -594,6 +644,7 @@ class Encoding:
 
     def _build_xy(
         self,
+        sub_id: str,
         feature_paths: dict[FeatureKey, Path],
         bold_metas: dict[BoldKey, BoldMeta],
     ) -> TrainingData:
@@ -617,12 +668,15 @@ class Encoding:
             expected = max(seg.slice.stop for seg in bold_meta.segments)
             actual = bold_arrays[bold_key].shape[0]
             if expected > actual:
-                first_bold = next(iter(bold_metas.values()))
-                sub_id = first_bold.bids.entities.get("sub")
-                loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
+                loc = _format_loc(
+                    sub=sub_id,
+                    ses=bold_key.ses,
+                    run=bold_key.run,
+                    space=self.bold_space,
+                )
                 raise ValueError(
-                    f"Segment slices extend to TR {expected} "
-                    f"but BOLD has only {actual} TRs for {loc}"
+                    f"events.tsv declares segments extending to TR {expected} "
+                    f"but BOLD at {loc} has only {actual} TRs"
                 )
 
         # None sorts before any value; empty string is a stable tiebreaker for ses/run

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -413,7 +413,9 @@ class Encoding:
                         f"Feature cell {cell_key!r} carries entities "
                         f"{sorted(illegal_keys)} that do not identify the run. "
                         f"For an unsegmented run, only ses and run are valid on "
-                        f"feature filenames — move descriptive metadata to events.json"
+                        f"feature filenames. To attach metadata, declare a segment "
+                        f"row in events.tsv and add descriptive attributes to "
+                        f"events.json SegmentMetadata."
                     )
                 resolved_feature_paths[feature_key] = path
                 continue

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -65,11 +65,12 @@ class BIDSTree:
         task: str | None,
         run: str | None,
         space: str,
+        desc: str,
     ) -> dict[str, str]:
         return {
             **self._identity_entities(sub, ses, task, run),
             "space": space,
-            "desc": "preproc",
+            "desc": desc,
         }
 
     def add_feature(
@@ -98,9 +99,10 @@ class BIDSTree:
         run: str | None = None,
         tr: float = 2.0,
         space: str = SPACE,
+        desc: str = "preproc",
         subdir: str | None = None,
     ) -> Path:
-        entities = self._bold_entities(sub, ses, task, run, space)
+        entities = self._bold_entities(sub, ses, task, run, space, desc)
         directory = self.bold_dir if subdir is None else self.bold_dir / subdir
         return self._write(
             directory,
@@ -158,7 +160,7 @@ class BIDSTree:
     ) -> Path:
         return self._write(
             self.bold_dir,
-            self._bold_entities(sub, ses, task, run, space),
+            self._bold_entities(sub, ses, task, run, space, "preproc"),
             suffix="boldref",
             ext=".nii.gz",
         )
@@ -172,7 +174,7 @@ class BIDSTree:
         run: str | None = None,
         space: str = SPACE,
     ) -> Path:
-        entities = {**self._bold_entities(sub, ses, task, run, space), "desc": "brain"}
+        entities = self._bold_entities(sub, ses, task, run, space, "brain")
         return self._write(
             self.bold_dir, entities, suffix="mask", ext=".nii.gz", sidecar_json="{}"
         )
@@ -185,9 +187,9 @@ class BIDSTree:
         task: str | None = TASK,
         run: str | None = None,
         space: str = SPACE,
-        label: str = "aparcaseg",
+        desc: str = "aparcaseg",
     ) -> Path:
-        entities = {**self._bold_entities(sub, ses, task, run, space), "desc": label}
+        entities = self._bold_entities(sub, ses, task, run, space, desc)
         return self._write(self.bold_dir, entities, suffix="dseg", ext=".nii.gz")
 
     def add_confounds(
@@ -232,9 +234,9 @@ class BIDSTree:
         self.add_boldref(sub=sub, ses=ses, task=task, run=run, space=space)
         self.add_brain_mask(sub=sub, ses=ses, task=task, run=run, space=space)
         self.add_dseg(
-            sub=sub, ses=ses, task=task, run=run, space=space, label="aparcaseg"
+            sub=sub, ses=ses, task=task, run=run, space=space, desc="aparcaseg"
         )
-        self.add_dseg(sub=sub, ses=ses, task=task, run=run, space=space, label="aseg")
+        self.add_dseg(sub=sub, ses=ses, task=task, run=run, space=space, desc="aseg")
         self.add_confounds(sub=sub, ses=ses, task=task, run=run)
         self.add_xfm(sub=sub, ses=ses, task=task, run=run)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -128,7 +128,7 @@ class BIDSTree:
             [{"trial_type": "block-1", "onset": 0.0, "duration": 100.0}]
 
         events_json, if provided, is written to the matching events.json sidecar
-        as raw JSON content (e.g., {"Segments": [{"block": "1", "cond": "R"}, ...]}).
+        as raw JSON (e.g., {"SegmentMetadata": [{"block": "1", "cond": "R"}, ...]}).
         """
         import json
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+
+import pytest
+
+SUB = "001"
+TASK = "conv"
+SPACE = "MNI152NLin6Asym"
+
+
+class BIDSTree:
+    """Minimal on-disk fixture for BIDS-derivatives tests.
+
+    Files are empty (touch-only); naming follows fMRIPrep BIDS-derivatives
+    convention. All three dirs are pre-created under a single tmp_path root.
+    """
+
+    def __init__(self, root: Path):
+        self.features_dir = root / "features"
+        self.bold_dir = root / "bold"
+        self.output_dir = root / "output"
+        for dir in (self.features_dir, self.bold_dir, self.output_dir):
+            dir.mkdir(parents=True)
+
+    def _stem(self, entities: dict[str, str]) -> str:
+        return "_".join(f"{k}-{v}" for k, v in entities.items())
+
+    def _write(
+        self,
+        directory: Path,
+        entities: dict[str, str],
+        *,
+        suffix: str | None = None,
+        ext: str,
+        sidecar_json: str | None = None,
+    ) -> Path:
+        directory.mkdir(parents=True, exist_ok=True)
+        stem = self._stem(entities)
+        name = stem if suffix is None else f"{stem}_{suffix}"
+        path = directory / f"{name}{ext}"
+        path.touch()
+        if sidecar_json is not None:
+            (directory / f"{name}.json").write_text(sidecar_json)
+        return path
+
+    def _identity_entities(
+        self,
+        sub: str,
+        ses: str | None,
+        task: str | None,
+        run: str | None,
+    ) -> dict[str, str]:
+        entities: dict[str, str] = {"sub": sub}
+        if ses is not None:
+            entities["ses"] = ses
+        if task is not None:
+            entities["task"] = task
+        if run is not None:
+            entities["run"] = run
+        return entities
+
+    def _bold_entities(
+        self,
+        sub: str,
+        ses: str | None,
+        task: str | None,
+        run: str | None,
+        space: str,
+    ) -> dict[str, str]:
+        return {
+            **self._identity_entities(sub, ses, task, run),
+            "space": space,
+            "desc": "preproc",
+        }
+
+    def add_feature(
+        self,
+        feature: str,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        subdir: str | None = None,
+        **extra_entities: str,
+    ) -> Path:
+        entities = self._identity_entities(sub, ses, task, run)
+        entities.update(extra_entities)
+        entities["feature"] = feature
+        directory = self.features_dir if subdir is None else self.features_dir / subdir
+        return self._write(directory, entities, ext=".parquet")
+
+    def add_bold(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        tr: float = 2.0,
+        space: str = SPACE,
+        subdir: str | None = None,
+    ) -> Path:
+        entities = self._bold_entities(sub, ses, task, run, space)
+        directory = self.bold_dir if subdir is None else self.bold_dir / subdir
+        return self._write(
+            directory,
+            entities,
+            suffix="bold",
+            ext=".nii.gz",
+            sidecar_json=f'{{"RepetitionTime": {tr}}}',
+        )
+
+    def add_events(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        rows: list[dict[str, str | float]] | None = None,
+        events_json: dict | None = None,
+    ) -> Path:
+        """Write an events.tsv file, optionally with a colocated events.json sidecar.
+
+        rows is a list of dicts with trial_type, onset, duration, e.g.:
+            [{"trial_type": "block-1", "onset": 0.0, "duration": 100.0}]
+
+        events_json, if provided, is written to the matching events.json sidecar
+        as raw JSON content (e.g., {"Segments": [{"block": "1", "cond": "R"}, ...]}).
+        """
+        import json
+
+        identity = self._identity_entities(sub, ses, task, run)
+        stem = self._stem(identity)
+
+        tsv_rows = []
+        if rows:
+            for row in rows:
+                tsv_rows.append(
+                    f"{row['trial_type']}\t{row['onset']}\t{row['duration']}"
+                )
+        events_path = self.bold_dir / f"{stem}_events.tsv"
+        events_path.write_text("trial_type\tonset\tduration\n" + "\n".join(tsv_rows))
+
+        if events_json is not None:
+            (self.bold_dir / f"{stem}_events.json").write_text(json.dumps(events_json))
+
+        return events_path
+
+    def add_boldref(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        space: str = SPACE,
+    ) -> Path:
+        return self._write(
+            self.bold_dir,
+            self._bold_entities(sub, ses, task, run, space),
+            suffix="boldref",
+            ext=".nii.gz",
+        )
+
+    def add_brain_mask(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        space: str = SPACE,
+    ) -> Path:
+        entities = {**self._bold_entities(sub, ses, task, run, space), "desc": "brain"}
+        return self._write(
+            self.bold_dir, entities, suffix="mask", ext=".nii.gz", sidecar_json="{}"
+        )
+
+    def add_dseg(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        space: str = SPACE,
+        label: str = "aparcaseg",
+    ) -> Path:
+        entities = {**self._bold_entities(sub, ses, task, run, space), "desc": label}
+        return self._write(self.bold_dir, entities, suffix="dseg", ext=".nii.gz")
+
+    def add_confounds(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+    ) -> Path:
+        entities = {**self._identity_entities(sub, ses, task, run), "desc": "confounds"}
+        return self._write(
+            self.bold_dir, entities, suffix="timeseries", ext=".tsv", sidecar_json="{}"
+        )
+
+    def add_xfm(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+    ) -> Path:
+        entities = {
+            **self._identity_entities(sub, ses, task, run),
+            "from": "T1w",
+            "to": "scanner",
+            "mode": "image",
+        }
+        return self._write(self.bold_dir, entities, suffix="xfm", ext=".txt")
+
+    def add_bold_siblings(
+        self,
+        *,
+        sub: str = SUB,
+        ses: str | None = None,
+        task: str | None = TASK,
+        run: str | None = None,
+        space: str = SPACE,
+    ) -> None:
+        """Drop the full set of realistic fMRIPrep sibling files for a BOLD run."""
+        self.add_boldref(sub=sub, ses=ses, task=task, run=run, space=space)
+        self.add_brain_mask(sub=sub, ses=ses, task=task, run=run, space=space)
+        self.add_dseg(
+            sub=sub, ses=ses, task=task, run=run, space=space, label="aparcaseg"
+        )
+        self.add_dseg(sub=sub, ses=ses, task=task, run=run, space=space, label="aseg")
+        self.add_confounds(sub=sub, ses=ses, task=task, run=run)
+        self.add_xfm(sub=sub, ses=ses, task=task, run=run)
+
+
+@pytest.fixture()
+def tree(tmp_path: Path) -> BIDSTree:
+    return BIDSTree(tmp_path)

--- a/tests/unit/test_bold.py
+++ b/tests/unit/test_bold.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from hypline.bold import load_events
+from hypline.bold import load_events_tsv as load_events
 
 
 def _write_events(

--- a/tests/unit/test_bold.py
+++ b/tests/unit/test_bold.py
@@ -112,7 +112,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "R"},
                     {"block": "2", "cond": "L"},
                 ]
@@ -130,7 +130,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "2", "cond": "L"},
                     {"block": "1", "cond": "R"},
                 ]
@@ -146,7 +146,7 @@ class TestLoadBoldMeta:
         tree.add_events(
             run="1",
             rows=_SEGMENT_ROWS,
-            events_json={"Segments": [{"block": "1"}, {"block": "2"}]},
+            events_json={"SegmentMetadata": [{"block": "1"}, {"block": "2"}]},
         )
         meta = load_bold_meta(bold_path)
         assert all(seg.metadata == {} for seg in meta.segments)
@@ -156,7 +156,9 @@ class TestLoadBoldMeta:
         tree.add_events(
             run="1",
             rows=_SEGMENT_ROWS,
-            events_json={"Segments": [{"cond": "R"}, {"block": "2", "cond": "L"}]},
+            events_json={
+                "SegmentMetadata": [{"cond": "R"}, {"block": "2", "cond": "L"}]
+            },
         )
         with pytest.raises(ValueError, match="missing segment entity key"):
             load_bold_meta(bold_path)
@@ -167,7 +169,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "R"},
                     {"block": "99", "cond": "L"},  # "99" not in tsv
                 ]
@@ -182,7 +184,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "R"},
                     {"block": "2"},  # missing "cond"
                 ]
@@ -197,7 +199,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "bad-key": "R"},
                     {"block": "2", "bad-key": "L"},
                 ]
@@ -212,7 +214,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "ses": "01"},
                     {"block": "2", "ses": "01"},
                 ]
@@ -227,7 +229,7 @@ class TestLoadBoldMeta:
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "has space"},
                     {"block": "2", "cond": "L"},
                 ]
@@ -249,7 +251,7 @@ class TestLoadBoldMeta:
         tree.add_events(
             run="1",
             rows=[{"trial_type": "rest", "onset": 0.0, "duration": 200.0}],
-            events_json={"Segments": [{"block": "1", "cond": "R"}]},
+            events_json={"SegmentMetadata": [{"block": "1", "cond": "R"}]},
         )
         with pytest.raises(ValueError, match="no BIDS key-value rows"):
             load_bold_meta(bold_path)

--- a/tests/unit/test_bold.py
+++ b/tests/unit/test_bold.py
@@ -1,154 +1,255 @@
-from pathlib import Path
-
 import pytest
 
-from hypline.bold import load_events_tsv as load_events
+from hypline.bids import BIDSPath
+from hypline.bold import load_bold_meta, load_events_tsv
 
-
-def _write_events(
-    dirpath: Path,
-    stem: str,
-    *,
-    content: str = "trial_type\tonset\tduration\n",
-) -> Path:
-    events_path = dirpath / (stem + "_events.tsv")
-    events_path.write_text(content)
-    return events_path
-
-
-def _write_bold(dirpath: Path, stem: str) -> Path:
-    bold_path = dirpath / (stem + "_bold.nii.gz")
-    bold_path.touch()
-    return bold_path
+from .conftest import SPACE, SUB, TASK, BIDSTree
 
 
 class TestLoadEvents:
-    def test_spec_compliant_events_returned(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(
-            tmp_path,
-            "sub-01_task-movie_run-1",
-        )
-        result = load_events(bold_path)
+    """
+    Sidecar resolution is shared between `load_events_tsv` and `load_events_json`
+    via `_resolve_run_sidecar`; exercising the `.tsv` variant here covers both.
+    The `.json` branch is exercised end-to-end through `TestLoadBoldMeta`.
+    """
+
+    def test_spec_compliant_events_returned(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(run="1")
+        result = load_events_tsv(bold_path)
         assert result is not None
         assert "trial_type" in result.columns
 
-    def test_canonical_events_returned_when_misnamed_sibling_also_present(
-        self, tmp_path: Path
-    ):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(tmp_path, "sub-01_task-movie_run-1")
-        _write_events(tmp_path, "sub-01_task-movie_run-1_desc-preproc")
-        result = load_events(bold_path)
-        assert result is not None
-        assert "trial_type" in result.columns
+    def test_no_events_returns_none(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        assert load_events_tsv(bold_path) is None
 
-    def test_no_events_returns_none(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        assert load_events(bold_path) is None
+    def test_misnamed_sibling_with_space_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        events_path = tree.add_events(run="1")
+        events_path.rename(BIDSPath(events_path).with_entity("space", SPACE).path)
+        with pytest.raises(ValueError, match="unexpected events"):
+            load_events_tsv(bold_path)
 
-    def test_misnamed_sibling_with_space_raises(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        with pytest.raises(ValueError, match="unexpected events file"):
-            load_events(bold_path)
+    def test_misnamed_sibling_with_desc_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        events_path = tree.add_events(run="1")
+        events_path.rename(BIDSPath(events_path).with_entity("desc", "preproc").path)
+        with pytest.raises(ValueError, match="unexpected events"):
+            load_events_tsv(bold_path)
 
-    def test_misnamed_sibling_with_desc_raises(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(
-            tmp_path,
-            "sub-01_task-movie_run-1_desc-preproc",
-        )
-        with pytest.raises(ValueError, match="unexpected events file"):
-            load_events(bold_path)
-
-    def test_misnamed_sibling_with_space_and_desc_raises(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        events_path = _write_events(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym_desc-preproc",
+    def test_misnamed_sibling_with_space_and_desc_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        events_path = tree.add_events(run="1")
+        events_path = events_path.rename(
+            BIDSPath(events_path)
+            .with_entity("space", SPACE)
+            .with_entity("desc", "preproc")
+            .path
         )
         with pytest.raises(ValueError, match=events_path.name):
-            load_events(bold_path)
+            load_events_tsv(bold_path)
 
-    def test_misnamed_sibling_with_reordered_entities_raises(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(
-            tmp_path,
-            "sub-01_run-1_task-movie",
-        )
-        with pytest.raises(ValueError, match="unexpected events file"):
-            load_events(bold_path)
+    def test_misnamed_sibling_with_reordered_entities_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        events_path = tree.bold_dir / f"sub-{SUB}_run-1_task-{TASK}_events.tsv"
+        events_path.write_text("trial_type\tonset\tduration\n")
+        with pytest.raises(ValueError, match="unexpected events"):
+            load_events_tsv(bold_path)
 
-    def test_multiple_misnamed_siblings_all_listed(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        for space in ("MNI152NLin2009cAsym", "T1w"):
-            _write_events(
-                tmp_path,
-                f"sub-01_task-movie_run-1_space-{space}",
-            )
+    def test_multiple_misnamed_siblings_all_listed(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        for space in (SPACE, "T1w"):
+            events_path = tree.add_events(run="1")
+            events_path.rename(BIDSPath(events_path).with_entity("space", space).path)
         with pytest.raises(ValueError) as exc_info:
-            load_events(bold_path)
+            load_events_tsv(bold_path)
         msg = str(exc_info.value)
-        assert "MNI152NLin2009cAsym" in msg
+        assert SPACE in msg
         assert "T1w" in msg
 
-    def test_unrelated_events_in_same_dir_ignored(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(
-            tmp_path,
-            "sub-02_task-movie_run-1",
-        )
-        assert load_events(bold_path) is None
+    def test_unrelated_events_in_same_dir_ignored(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(sub="002", run="1")
+        assert load_events_tsv(bold_path) is None
 
-    def test_different_run_events_in_same_dir_ignored(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
-        )
-        _write_events(
-            tmp_path,
-            "sub-01_task-movie_run-2",
-        )
-        assert load_events(bold_path) is None
+    def test_different_run_events_in_same_dir_ignored(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(run="2")
+        assert load_events_tsv(bold_path) is None
 
-    def test_misnamed_sibling_for_different_run_ignored(self, tmp_path: Path):
-        bold_path = _write_bold(
-            tmp_path,
-            "sub-01_task-movie_run-1_space-MNI152NLin2009cAsym",
+    def test_misnamed_sibling_for_different_run_ignored(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        events_path = tree.add_events(run="2")
+        events_path.rename(BIDSPath(events_path).with_entity("space", SPACE).path)
+        assert load_events_tsv(bold_path) is None
+
+
+_SEGMENT_ROWS = [
+    {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+    {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+]
+
+
+class TestLoadBoldMeta:
+    def test_events_json_absent_passes(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(run="1", rows=_SEGMENT_ROWS)
+        meta = load_bold_meta(bold_path)
+        assert all(seg.metadata == {} for seg in meta.segments)
+
+    def test_events_json_without_segments_field_passes(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1", rows=_SEGMENT_ROWS, events_json={"SomeOtherField": "value"}
         )
-        _write_events(
-            tmp_path,
-            "sub-01_task-movie_run-2_space-MNI152NLin2009cAsym",
+        meta = load_bold_meta(bold_path)
+        assert all(seg.metadata == {} for seg in meta.segments)
+
+    def test_metadata_merged_into_segments(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "R"},
+                    {"block": "2", "cond": "L"},
+                ]
+            },
         )
-        assert load_events(bold_path) is None
+        meta = load_bold_meta(bold_path)
+        assert len(meta.segments) == 2
+        by_value = {seg.value: seg for seg in meta.segments}
+        assert by_value["1"].metadata == {"cond": "R"}
+        assert by_value["2"].metadata == {"cond": "L"}
+
+    def test_reversed_record_order_merges_by_value(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "2", "cond": "L"},
+                    {"block": "1", "cond": "R"},
+                ]
+            },
+        )
+        meta = load_bold_meta(bold_path)
+        by_value = {seg.value: seg for seg in meta.segments}
+        assert by_value["1"].metadata == {"cond": "R"}
+        assert by_value["2"].metadata == {"cond": "L"}
+
+    def test_records_with_only_segment_entity_key(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={"Segments": [{"block": "1"}, {"block": "2"}]},
+        )
+        meta = load_bold_meta(bold_path)
+        assert all(seg.metadata == {} for seg in meta.segments)
+
+    def test_events_json_record_missing_segment_entity_key_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={"Segments": [{"cond": "R"}, {"block": "2", "cond": "L"}]},
+        )
+        with pytest.raises(ValueError, match="missing segment entity key"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_segment_value_mismatch_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "R"},
+                    {"block": "99", "cond": "L"},  # "99" not in tsv
+                ]
+            },
+        )
+        with pytest.raises(ValueError, match="do not match events.tsv"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_schema_mismatch_across_records_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "R"},
+                    {"block": "2"},  # missing "cond"
+                ]
+            },
+        )
+        with pytest.raises(ValueError, match="inconsistent metadata keys"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_extra_key_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "1", "bad-key": "R"},
+                    {"block": "2", "bad-key": "L"},
+                ]
+            },
+        )
+        with pytest.raises(ValueError, match="invalid"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_reserved_key_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "1", "ses": "01"},
+                    {"block": "2", "ses": "01"},
+                ]
+            },
+        )
+        with pytest.raises(ValueError, match="collides with BOLD identity entity"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_invalid_value_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "has space"},
+                    {"block": "2", "cond": "L"},
+                ]
+            },
+        )
+        with pytest.raises(ValueError, match="invalid"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_misnamed_sibling_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        events_path = tree.add_events(run="1", rows=_SEGMENT_ROWS, events_json={})
+        events_json = events_path.with_suffix(".json")
+        events_json.rename(BIDSPath(events_json).with_entity("space", SPACE).path)
+        with pytest.raises(ValueError, match="unexpected events"):
+            load_bold_meta(bold_path)
+
+    def test_events_json_with_segments_but_no_tsv_segments_raises(self, tree: BIDSTree):
+        bold_path = tree.add_bold(run="1")
+        tree.add_events(
+            run="1",
+            rows=[{"trial_type": "rest", "onset": 0.0, "duration": 200.0}],
+            events_json={"Segments": [{"block": "1", "cond": "R"}]},
+        )
+        with pytest.raises(ValueError, match="no BIDS key-value rows"):
+            load_bold_meta(bold_path)

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -1,256 +1,15 @@
-from pathlib import Path
-
 import pytest
 
 from hypline.encoding import BoldKey, CellKey, Encoding, EncodingConfig, FeatureKey
 
-_DEFAULT_SUB = "001"
-_DEFAULT_TASK = "conv"
-_DEFAULT_SPACE = "MNI152NLin6Asym"
-
-
-class BIDSTree:
-    """Minimal on-disk fixture for an Encoding test session.
-
-    Files are empty (touch-only); naming follows fMRIPrep BIDS-derivatives
-    convention. All three dirs are pre-created under a single tmp_path root.
-    """
-
-    def __init__(self, root: Path):
-        self.features_dir = root / "features"
-        self.bold_dir = root / "bold"
-        self.output_dir = root / "output"
-        for dir in (self.features_dir, self.bold_dir, self.output_dir):
-            dir.mkdir(parents=True)
-
-    def _stem(self, entities: dict[str, str]) -> str:
-        return "_".join(f"{k}-{v}" for k, v in entities.items())
-
-    def _write(
-        self,
-        directory: Path,
-        entities: dict[str, str],
-        *,
-        suffix: str | None = None,
-        ext: str,
-        sidecar_json: str | None = None,
-    ) -> Path:
-        directory.mkdir(parents=True, exist_ok=True)
-        stem = self._stem(entities)
-        name = stem if suffix is None else f"{stem}_{suffix}"
-        path = directory / f"{name}{ext}"
-        path.touch()
-        if sidecar_json is not None:
-            (directory / f"{name}.json").write_text(sidecar_json)
-        return path
-
-    def _identity_entities(
-        self,
-        sub: str,
-        ses: str | None,
-        task: str | None,
-        run: str | None,
-    ) -> dict[str, str]:
-        entities: dict[str, str] = {"sub": sub}
-        if ses is not None:
-            entities["ses"] = ses
-        if task is not None:
-            entities["task"] = task
-        if run is not None:
-            entities["run"] = run
-        return entities
-
-    def _bold_entities(
-        self,
-        sub: str,
-        ses: str | None,
-        task: str | None,
-        run: str | None,
-        space: str,
-    ) -> dict[str, str]:
-        return {
-            **self._identity_entities(sub, ses, task, run),
-            "space": space,
-            "desc": "preproc",
-        }
-
-    def add_feature(
-        self,
-        feature: str,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        subdir: str | None = None,
-        **extra_entities: str,
-    ) -> Path:
-        entities = self._identity_entities(sub, ses, task, run)
-        entities.update(extra_entities)
-        entities["feature"] = feature
-        directory = self.features_dir if subdir is None else self.features_dir / subdir
-        return self._write(directory, entities, ext=".parquet")
-
-    def add_bold(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        tr: float = 2.0,
-        space: str = _DEFAULT_SPACE,
-        subdir: str | None = None,
-    ) -> Path:
-        entities = self._bold_entities(sub, ses, task, run, space)
-        directory = self.bold_dir if subdir is None else self.bold_dir / subdir
-        return self._write(
-            directory,
-            entities,
-            suffix="bold",
-            ext=".nii.gz",
-            sidecar_json=f'{{"RepetitionTime": {tr}}}',
-        )
-
-    def add_events(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        rows: list[dict[str, str | float]] | None = None,
-        events_json: dict | None = None,
-    ) -> Path:
-        """Write an events.tsv file, optionally with a colocated events.json sidecar.
-
-        rows is a list of dicts with trial_type, onset, duration, e.g.:
-            [{"trial_type": "block-1", "onset": 0.0, "duration": 100.0}]
-
-        events_json, if provided, is written to the matching events.json sidecar
-        as raw JSON content (e.g., {"Segments": [{"block": "1", "cond": "R"}, ...]}).
-        """
-        import json
-
-        identity = self._identity_entities(sub, ses, task, run)
-        stem = self._stem(identity)
-
-        tsv_rows = []
-        if rows:
-            for row in rows:
-                tsv_rows.append(
-                    f"{row['trial_type']}\t{row['onset']}\t{row['duration']}"
-                )
-        events_path = self.bold_dir / f"{stem}_events.tsv"
-        events_path.write_text("trial_type\tonset\tduration\n" + "\n".join(tsv_rows))
-
-        if events_json is not None:
-            (self.bold_dir / f"{stem}_events.json").write_text(json.dumps(events_json))
-
-        return events_path
-
-    def add_boldref(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        space: str = _DEFAULT_SPACE,
-    ) -> Path:
-        return self._write(
-            self.bold_dir,
-            self._bold_entities(sub, ses, task, run, space),
-            suffix="boldref",
-            ext=".nii.gz",
-        )
-
-    def add_brain_mask(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        space: str = _DEFAULT_SPACE,
-    ) -> Path:
-        entities = {**self._bold_entities(sub, ses, task, run, space), "desc": "brain"}
-        return self._write(
-            self.bold_dir, entities, suffix="mask", ext=".nii.gz", sidecar_json="{}"
-        )
-
-    def add_dseg(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        space: str = _DEFAULT_SPACE,
-        label: str = "aparcaseg",
-    ) -> Path:
-        entities = {**self._bold_entities(sub, ses, task, run, space), "desc": label}
-        return self._write(self.bold_dir, entities, suffix="dseg", ext=".nii.gz")
-
-    def add_confounds(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-    ) -> Path:
-        entities = {**self._identity_entities(sub, ses, task, run), "desc": "confounds"}
-        return self._write(
-            self.bold_dir, entities, suffix="timeseries", ext=".tsv", sidecar_json="{}"
-        )
-
-    def add_xfm(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-    ) -> Path:
-        entities = {
-            **self._identity_entities(sub, ses, task, run),
-            "from": "T1w",
-            "to": "scanner",
-            "mode": "image",
-        }
-        return self._write(self.bold_dir, entities, suffix="xfm", ext=".txt")
-
-    def add_bold_siblings(
-        self,
-        *,
-        sub: str = _DEFAULT_SUB,
-        ses: str | None = None,
-        task: str | None = _DEFAULT_TASK,
-        run: str | None = None,
-        space: str = _DEFAULT_SPACE,
-    ) -> None:
-        """Drop the full set of realistic fMRIPrep sibling files for a BOLD run."""
-        self.add_boldref(sub=sub, ses=ses, task=task, run=run, space=space)
-        self.add_brain_mask(sub=sub, ses=ses, task=task, run=run, space=space)
-        self.add_dseg(
-            sub=sub, ses=ses, task=task, run=run, space=space, label="aparcaseg"
-        )
-        self.add_dseg(sub=sub, ses=ses, task=task, run=run, space=space, label="aseg")
-        self.add_confounds(sub=sub, ses=ses, task=task, run=run)
-        self.add_xfm(sub=sub, ses=ses, task=task, run=run)
-
-
-@pytest.fixture()
-def tree(tmp_path: Path) -> BIDSTree:
-    return BIDSTree(tmp_path)
+from .conftest import SPACE, SUB, TASK, BIDSTree
 
 
 def make_encoding(
     tree: BIDSTree,
     features: list[str],
     *,
-    bold_space: str = _DEFAULT_SPACE,
+    bold_space: str = SPACE,
     bids_filters: list[str] | None = None,
 ) -> Encoding:
     return Encoding(
@@ -315,21 +74,21 @@ class TestDiscoverFeatures:
     def test_returns_expected_keys(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
         expected = FeatureKey(cell=CellKey(run="1"), feature="mfcc")
         assert expected in feature_paths
 
     def test_no_files_raises(self, tree: BIDSTree):
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(FileNotFoundError, match="No matching feature files"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_duplicate_feature_file_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
         tree.add_feature("mfcc", run="1", subdir="sub")
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Multiple feature files"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_missing_feature_at_one_cell_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
@@ -337,13 +96,13 @@ class TestDiscoverFeatures:
         tree.add_feature("clip", run="1")
         enc = make_encoding(tree, ["mfcc", "clip"])
         with pytest.raises(FileNotFoundError, match="Missing feature=clip"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_semantic_entity_filter_narrows_results(self, tree: BIDSTree):
         tree.add_feature("mfcc", block="a")
         tree.add_feature("mfcc", block="b")
         enc = make_encoding(tree, ["mfcc"], bids_filters=["block-a"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
         assert {k.cell.get("block") for k in feature_paths} == {"a"}
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
@@ -351,34 +110,34 @@ class TestDiscoverFeatures:
         tree.add_feature("mfcc", task="conv", run="2")
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_acquisition_entities_not_required_on_features(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
         enc = make_encoding(tree, ["mfcc"], bids_filters=["desc-preproc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
         expected = FeatureKey(cell=CellKey(run="1"), feature="mfcc")
         assert expected in feature_paths
 
-    def test_mixed_partitioned_unpartitioned_runs_raise(self, tree: BIDSTree):
+    def test_mixed_segmented_unsegmented_runs_raise(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1", block="1")
         tree.add_feature("mfcc", run="2")
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent feature file schemas"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_typo_filter_entity_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
         enc = make_encoding(tree, ["mfcc"], bids_filters=["typo-foo"])
         with pytest.raises(ValueError, match="typo"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_absent_common_entity_filter_raises(self, tree: BIDSTree):
         # ses not on any file — filter can't match, entity check fires
         tree.add_feature("mfcc", run="1")
         enc = make_encoding(tree, ["mfcc"], bids_filters=["ses-99"])
         with pytest.raises(ValueError, match="ses"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_valid_entity_wrong_value_gives_file_not_found(self, tree: BIDSTree):
         # block is on files — filter entity is valid, just no match for block-99
@@ -386,7 +145,7 @@ class TestDiscoverFeatures:
         tree.add_feature("mfcc", block="2")
         enc = make_encoding(tree, ["mfcc"], bids_filters=["block-99"])
         with pytest.raises(FileNotFoundError):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
     def test_schema_error_fires_before_coverage_error(self, tree: BIDSTree):
         # clip missing at run-2, but schema mismatch should raise first
@@ -395,33 +154,33 @@ class TestDiscoverFeatures:
         tree.add_feature("clip", run="1", block="1")
         enc = make_encoding(tree, ["mfcc", "clip"])
         with pytest.raises(ValueError, match="Inconsistent feature file schemas"):
-            enc._discover_features(_DEFAULT_SUB)
+            enc._discover_features(SUB)
 
 
 class TestDiscoverBold:
     def test_returns_expected_keys(self, tree: BIDSTree):
         tree.add_bold(run="1")
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses=None, run="1") in bold_metas
 
     def test_no_files_raises(self, tree: BIDSTree):
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(FileNotFoundError, match="No BOLD files"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_duplicate_bold_raises(self, tree: BIDSTree):
         tree.add_bold(run="1")
         tree.add_bold(run="1", subdir="sub")
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Duplicate BOLD"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_cross_session_runs_distinguished(self, tree: BIDSTree):
         tree.add_bold(ses="1", run="1")
         tree.add_bold(ses="2", run="1")
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses="1", run="1") in bold_metas
         assert BoldKey(ses="2", run="1") in bold_metas
 
@@ -429,14 +188,14 @@ class TestDiscoverBold:
         tree.add_bold(run="1")
         tree.add_bold_siblings(run="1")
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_wrong_space_bold_excluded(self, tree: BIDSTree):
         tree.add_bold(run="1", space="MNI152NLin6Asym")
         tree.add_bold(run="1", space="T1w")
         enc = make_encoding(tree, ["mfcc"], bold_space="MNI152NLin6Asym")
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_inconsistent_tr_raises(self, tree: BIDSTree):
@@ -444,31 +203,31 @@ class TestDiscoverBold:
         tree.add_bold(run="2", tr=1.5)
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent repetition times"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
         tree.add_bold(task="rest", run="1")
         tree.add_bold(task="conv", run="2")
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_acq_invariance_violation_raises(self, tree: BIDSTree):
         for acq, run in (("hi", "1"), ("lo", "2")):
             stem = (
-                f"sub-{_DEFAULT_SUB}_task-{_DEFAULT_TASK}_acq-{acq}_run-{run}_"
-                f"space-{_DEFAULT_SPACE}_desc-preproc_bold"
+                f"sub-{SUB}_task-{TASK}_acq-{acq}_run-{run}_"
+                f"space-{SPACE}_desc-preproc_bold"
             )
             (tree.bold_dir / f"{stem}.nii.gz").touch()
             (tree.bold_dir / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="acq"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_no_events_gives_no_segments(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
         assert meta.segments == []
 
@@ -482,7 +241,7 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
         assert len(meta.segments) == 2
         assert meta.segments[0].entity == "block"
@@ -502,7 +261,7 @@ class TestDiscoverBold:
         )
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="multiple BIDS key-value entities"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_segment_entity_as_flat_label_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -515,7 +274,7 @@ class TestDiscoverBold:
         )
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="also appears as a flat label"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_duplicate_segment_values_raise(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -528,7 +287,7 @@ class TestDiscoverBold:
         )
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="appears more than once"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_overlapping_slices_raise(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -541,7 +300,7 @@ class TestDiscoverBold:
         )
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="overlap"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
     def test_leading_break_allowed(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -553,7 +312,7 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
         assert len(meta.segments) == 2
         assert meta.segments[0].slice == slice(5, 50)
@@ -561,11 +320,11 @@ class TestDiscoverBold:
     def test_hyphen_free_trial_type_ignored(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         events_path = (
-            tree.bold_dir / f"sub-{_DEFAULT_SUB}_task-{_DEFAULT_TASK}_run-1_events.tsv"
+            tree.bold_dir / f"sub-{SUB}_task-{TASK}_run-1_events.tsv"
         )
         events_path.write_text("trial_type\tonset\tduration\nrest\t0.0\t100.0\n")
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
         assert meta.segments == []
 
@@ -579,7 +338,7 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
         assert len(meta.segments) == 2
 
@@ -594,12 +353,12 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
         assert len(meta.segments) == 2
         assert meta.segments[0].entity == "block"
 
-    def test_runs_disagree_on_partition_entity_raises(self, tree: BIDSTree):
+    def test_runs_disagree_on_segment_entity_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_bold(run="2", tr=2.0)
         tree.add_events(
@@ -618,9 +377,9 @@ class TestDiscoverBold:
         )
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="disagree on segment entity"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
-    def test_mixed_partitioned_and_unpartitioned_raises(self, tree: BIDSTree):
+    def test_mixed_segmented_and_unsegmented_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_bold(run="2", tr=2.0)  # no events → unsegmented
         tree.add_events(
@@ -632,13 +391,47 @@ class TestDiscoverBold:
         )
         enc = make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="disagree on segment entity"):
-            enc._discover_bold(_DEFAULT_SUB)
+            enc._discover_bold(SUB)
 
-    def test_all_unpartitioned_passes(self, tree: BIDSTree):
+    def test_events_json_cross_run_schema_mismatch_raises(self, tree: BIDSTree):
+        rows = [
+            {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+            {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+        ]
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(run="2", tr=2.0)
+
+        # run-1 has metadata key "cond"; run-2 has metadata key "item"
+        tree.add_events(
+            run="1",
+            rows=rows,
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "R"},
+                    {"block": "2", "cond": "L"},
+                ]
+            },
+        )
+        tree.add_events(
+            run="2",
+            rows=rows,
+            events_json={
+                "Segments": [
+                    {"block": "1", "item": "A"},
+                    {"block": "2", "item": "B"},
+                ]
+            },
+        )
+
+        enc = make_encoding(tree, ["mfcc"])
+        with pytest.raises(ValueError, match="disagree on segment metadata schema"):
+            enc._discover_bold(SUB)
+
+    def test_all_unsegmented_passes(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_bold(run="2", tr=2.0)
         enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(SUB)
         assert all(meta.segments == [] for meta in bold_metas.values())
 
 
@@ -647,16 +440,16 @@ class TestValidateAlignment:
         tree.add_feature("mfcc", run="1")
         tree.add_bold(run="1")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         enc._validate_alignment(feature_paths, bold_metas)
 
     def test_cross_file_task_invariance_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", task="rest", run="1")
         tree.add_bold(task="conv", run="1")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="task"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -665,8 +458,8 @@ class TestValidateAlignment:
         tree.add_bold(run="1")
         tree.add_bold(run="2")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="No feature files found for BOLD"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -675,8 +468,8 @@ class TestValidateAlignment:
         tree.add_feature("mfcc", run="2")
         tree.add_bold(run="1")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="No BOLD file found for features"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -687,8 +480,8 @@ class TestValidateAlignment:
         tree.add_bold(run="4")
         tree.add_bold(run="5")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="other coverage gaps"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -699,8 +492,8 @@ class TestValidateAlignment:
         tree.add_feature("mfcc", run="4")
         tree.add_feature("mfcc", run="5")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="other coverage gaps"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -716,8 +509,8 @@ class TestValidateAlignment:
         tree.add_feature("mfcc", run="1", block="1")
         tree.add_feature("mfcc", run="1", block="2")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         enc._validate_alignment(feature_paths, bold_metas)
 
     def test_cell_missing_segment_entity_raises(self, tree: BIDSTree):
@@ -731,8 +524,8 @@ class TestValidateAlignment:
         )
         tree.add_feature("mfcc", run="1")  # no block entity on the filename
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="missing segment entity"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -747,8 +540,8 @@ class TestValidateAlignment:
         )
         tree.add_feature("mfcc", run="1", block="3")  # block-3 not in events
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="not found in events"):
             enc._validate_alignment(feature_paths, bold_metas)
 
@@ -757,12 +550,12 @@ class TestValidateAlignment:
         tree.add_feature("mfcc", run="1", trial="1")
         tree.add_feature("mfcc", run="1", trial="2")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="unsegmented but has 2 feature cells"):
             enc._validate_alignment(feature_paths, bold_metas)
 
-    def test_apparent_partition_entity_without_events_passes_silently(
+    def test_apparent_segment_entity_without_events_passes_silently(
         self, tree: BIDSTree
     ):
         # Blind spot: trial-1 on filename without events.tsv is indistinguishable
@@ -770,6 +563,6 @@ class TestValidateAlignment:
         tree.add_bold(run="1", tr=2.0)
         tree.add_feature("mfcc", run="1", trial="1")
         enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(_DEFAULT_SUB)
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
         enc._validate_alignment(feature_paths, bold_metas)  # does not raise

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -120,21 +120,33 @@ class BIDSTree:
         task: str | None = _DEFAULT_TASK,
         run: str | None = None,
         rows: list[dict[str, str | float]] | None = None,
+        events_json: dict | None = None,
     ) -> Path:
-        """Write an events.tsv file.
+        """Write an events.tsv file, optionally with a colocated events.json sidecar.
 
         rows is a list of dicts with trial_type, onset, duration, e.g.:
             [{"trial_type": "block-1", "onset": 0.0, "duration": 100.0}]
+
+        events_json, if provided, is written to the matching events.json sidecar
+        as raw JSON content (e.g., {"Segments": [{"block": "1", "cond": "R"}, ...]}).
         """
+        import json
+
         identity = self._identity_entities(sub, ses, task, run)
+        stem = self._stem(identity)
+
         tsv_rows = []
         if rows:
             for row in rows:
                 tsv_rows.append(
                     f"{row['trial_type']}\t{row['onset']}\t{row['duration']}"
                 )
-        events_path = self.bold_dir / f"{self._stem(identity)}_events.tsv"
+        events_path = self.bold_dir / f"{stem}_events.tsv"
         events_path.write_text("trial_type\tonset\tduration\n" + "\n".join(tsv_rows))
+
+        if events_json is not None:
+            (self.bold_dir / f"{stem}_events.json").write_text(json.dumps(events_json))
+
         return events_path
 
     def add_boldref(
@@ -453,12 +465,12 @@ class TestDiscoverBold:
         with pytest.raises(ValueError, match="acq"):
             enc._discover_bold(_DEFAULT_SUB)
 
-    def test_no_events_gives_no_partitioning(self, tree: BIDSTree):
+    def test_no_events_gives_no_segments(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         enc = make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.partitioning is None
+        assert meta.segments == []
 
     def test_structural_entity_slices_parsed(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -472,41 +484,79 @@ class TestDiscoverBold:
         enc = make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.partitioning is not None
-        assert meta.partitioning.entity == "block"
-        assert meta.partitioning.slices["1"] == slice(0, 50)
-        assert meta.partitioning.slices["2"] == slice(50, 100)
+        assert len(meta.segments) == 2
+        assert meta.segments[0].entity == "block"
+        assert meta.segments[0].value == "1"
+        assert meta.segments[0].slice == slice(0, 50)
+        assert meta.segments[1].value == "2"
+        assert meta.segments[1].slice == slice(50, 100)
 
-    def test_leaf_entity_is_finest_granularity(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_events(
-            run="1",
-            rows=[
-                {"trial_type": "block-1", "onset": 0.0, "duration": 200.0},
-                {"trial_type": "trial-1", "onset": 0.0, "duration": 100.0},
-                {"trial_type": "trial-2", "onset": 100.0, "duration": 100.0},
-            ],
-        )
-        enc = make_encoding(tree, ["mfcc"])
-        bold_metas = enc._discover_bold(_DEFAULT_SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.partitioning is not None
-        assert meta.partitioning.entity == "trial"
-
-    def test_tied_granularity_raises(self, tree: BIDSTree):
+    def test_multiple_kv_entities_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
-                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
-                {"trial_type": "segment-a", "onset": 0.0, "duration": 100.0},
-                {"trial_type": "segment-b", "onset": 100.0, "duration": 100.0},
+                {"trial_type": "trial-1", "onset": 100.0, "duration": 100.0},
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        with pytest.raises(ValueError, match="identical granularity"):
+        with pytest.raises(ValueError, match="multiple BIDS key-value entities"):
             enc._discover_bold(_DEFAULT_SUB)
+
+    def test_segment_entity_as_flat_label_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        enc = make_encoding(tree, ["mfcc"])
+        with pytest.raises(ValueError, match="also appears as a flat label"):
+            enc._discover_bold(_DEFAULT_SUB)
+
+    def test_duplicate_segment_values_raise(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-1", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        enc = make_encoding(tree, ["mfcc"])
+        with pytest.raises(ValueError, match="appears more than once"):
+            enc._discover_bold(_DEFAULT_SUB)
+
+    def test_overlapping_slices_raise(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 120.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        enc = make_encoding(tree, ["mfcc"])
+        with pytest.raises(ValueError, match="overlap"):
+            enc._discover_bold(_DEFAULT_SUB)
+
+    def test_leading_break_allowed(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 10.0, "duration": 90.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        enc = make_encoding(tree, ["mfcc"])
+        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert len(meta.segments) == 2
+        assert meta.segments[0].slice == slice(5, 50)
 
     def test_hyphen_free_trial_type_ignored(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -517,9 +567,9 @@ class TestDiscoverBold:
         enc = make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.partitioning is None
+        assert meta.segments == []
 
-    def test_non_tiling_kv_entity_raises(self, tree: BIDSTree):
+    def test_kv_entity_with_gap_passes(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -529,34 +579,11 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        with pytest.raises(ValueError, match="do not partition the run"):
-            enc._discover_bold(_DEFAULT_SUB)
+        bold_metas = enc._discover_bold(_DEFAULT_SUB)
+        meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert len(meta.segments) == 2
 
-    def test_kv_entity_not_starting_at_zero_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_events(
-            run="1",
-            rows=[{"trial_type": "block-1", "onset": 10.0, "duration": 90.0}],
-        )
-        enc = make_encoding(tree, ["mfcc"])
-        with pytest.raises(ValueError, match="do not partition the run"):
-            enc._discover_bold(_DEFAULT_SUB)
-
-    def test_partial_tiling_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_events(
-            run="1",
-            rows=[
-                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
-                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
-                {"trial_type": "trial-1", "onset": 0.0, "duration": 100.0},
-            ],
-        )
-        enc = make_encoding(tree, ["mfcc"])
-        with pytest.raises(ValueError, match="do not partition the run"):
-            enc._discover_bold(_DEFAULT_SUB)
-
-    def test_tiling_with_flat_labels_passes(self, tree: BIDSTree):
+    def test_flat_labels_alongside_segments_ignored(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -569,8 +596,8 @@ class TestDiscoverBold:
         enc = make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
         meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.partitioning is not None
-        assert meta.partitioning.entity == "block"
+        assert len(meta.segments) == 2
+        assert meta.segments[0].entity == "block"
 
     def test_runs_disagree_on_partition_entity_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -590,12 +617,12 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        with pytest.raises(ValueError, match="disagree on partition entity"):
+        with pytest.raises(ValueError, match="disagree on segment entity"):
             enc._discover_bold(_DEFAULT_SUB)
 
     def test_mixed_partitioned_and_unpartitioned_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=2.0)  # no events → unpartitioned
+        tree.add_bold(run="2", tr=2.0)  # no events → unsegmented
         tree.add_events(
             run="1",
             rows=[
@@ -604,7 +631,7 @@ class TestDiscoverBold:
             ],
         )
         enc = make_encoding(tree, ["mfcc"])
-        with pytest.raises(ValueError, match="disagree on partition entity"):
+        with pytest.raises(ValueError, match="disagree on segment entity"):
             enc._discover_bold(_DEFAULT_SUB)
 
     def test_all_unpartitioned_passes(self, tree: BIDSTree):
@@ -612,7 +639,7 @@ class TestDiscoverBold:
         tree.add_bold(run="2", tr=2.0)
         enc = make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
-        assert all(meta.partitioning is None for meta in bold_metas.values())
+        assert all(meta.segments == [] for meta in bold_metas.values())
 
 
 class TestValidateAlignment:
@@ -677,7 +704,7 @@ class TestValidateAlignment:
         with pytest.raises(FileNotFoundError, match="other coverage gaps"):
             enc._validate_alignment(feature_paths, bold_metas)
 
-    def test_partitioned_valid_cells_pass(self, tree: BIDSTree):
+    def test_segmented_valid_cells_pass(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -693,7 +720,7 @@ class TestValidateAlignment:
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
         enc._validate_alignment(feature_paths, bold_metas)
 
-    def test_cell_missing_partition_entity_raises(self, tree: BIDSTree):
+    def test_cell_missing_segment_entity_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -706,7 +733,7 @@ class TestValidateAlignment:
         enc = make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(_DEFAULT_SUB)
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
-        with pytest.raises(ValueError, match="missing partition entity"):
+        with pytest.raises(ValueError, match="missing segment entity"):
             enc._validate_alignment(feature_paths, bold_metas)
 
     def test_cell_value_not_in_events_raises(self, tree: BIDSTree):
@@ -725,14 +752,14 @@ class TestValidateAlignment:
         with pytest.raises(ValueError, match="not found in events"):
             enc._validate_alignment(feature_paths, bold_metas)
 
-    def test_unpartitioned_run_multiple_cells_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)  # no events → unpartitioned
+    def test_unsegmented_run_multiple_cells_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
         tree.add_feature("mfcc", run="1", trial="1")
         tree.add_feature("mfcc", run="1", trial="2")
         enc = make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(_DEFAULT_SUB)
         bold_metas = enc._discover_bold(_DEFAULT_SUB)
-        with pytest.raises(ValueError, match="unpartitioned but has 2 feature cells"):
+        with pytest.raises(ValueError, match="unsegmented but has 2 feature cells"):
             enc._validate_alignment(feature_paths, bold_metas)
 
     def test_apparent_partition_entity_without_events_passes_silently(

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -376,7 +376,7 @@ class TestDiscoverBold:
             run="1",
             rows=rows,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "R"},
                     {"block": "2", "cond": "L"},
                 ]
@@ -386,7 +386,7 @@ class TestDiscoverBold:
             run="2",
             rows=rows,
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "item": "A"},
                     {"block": "2", "item": "B"},
                 ]
@@ -542,7 +542,7 @@ class TestResolveCellKeys:
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "R"},
                     {"block": "2", "cond": "L"},
                 ]
@@ -566,7 +566,7 @@ class TestResolveCellKeys:
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
             ],
-            events_json={"Segments": [{"block": "1", "cond": "R"}]},
+            events_json={"SegmentMetadata": [{"block": "1", "cond": "R"}]},
         )
         tree.add_feature("mfcc", run="1", block="1", cond="R")
         enc = _make_encoding(tree, ["mfcc"])
@@ -582,7 +582,7 @@ class TestResolveCellKeys:
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
             ],
-            events_json={"Segments": [{"block": "1", "cond": "R"}]},
+            events_json={"SegmentMetadata": [{"block": "1", "cond": "R"}]},
         )
         tree.add_feature("mfcc", run="1", block="1", cond="L")
         enc = _make_encoding(tree, ["mfcc"])
@@ -690,7 +690,7 @@ class TestApplyFilters:
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
             events_json={
-                "Segments": [
+                "SegmentMetadata": [
                     {"block": "1", "cond": "R"},
                     {"block": "2", "cond": "L"},
                 ]

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -5,7 +5,7 @@ from hypline.encoding import BoldKey, CellKey, Encoding, EncodingConfig, Feature
 from .conftest import SPACE, SUB, TASK, BIDSTree
 
 
-def make_encoding(
+def _make_encoding(
     tree: BIDSTree,
     features: list[str],
     *,
@@ -25,28 +25,28 @@ def make_encoding(
 
 class TestEncodingInit:
     def test_valid_config_succeeds(self, tree: BIDSTree):
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         assert enc.features == ["mfcc"]
 
     def test_empty_features_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="non-empty"):
-            make_encoding(tree, [])
+            _make_encoding(tree, [])
 
     def test_duplicate_features_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="Duplicate"):
-            make_encoding(tree, ["mfcc", "mfcc"])
+            _make_encoding(tree, ["mfcc", "mfcc"])
 
     def test_reserved_entity_in_filters_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="sub"):
-            make_encoding(tree, ["mfcc"], bids_filters=["sub-001"])
+            _make_encoding(tree, ["mfcc"], bids_filters=["sub-001"])
 
     def test_unknown_entity_accepted_at_init(self, tree: BIDSTree):
-        enc = make_encoding(tree, ["mfcc"], bids_filters=["xyz-foo"])
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["xyz-foo"])
         assert enc.bids_filters == ["xyz-foo"]
 
     def test_invalid_bold_space_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="Unsupported BOLD data space"):
-            make_encoding(tree, ["mfcc"], bold_space="notaspace")
+            _make_encoding(tree, ["mfcc"], bold_space="notaspace")
 
 
 class TestCellKey:
@@ -73,20 +73,20 @@ class TestCellKey:
 class TestDiscoverFeatures:
     def test_returns_expected_keys(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         expected = FeatureKey(cell=CellKey(run="1"), feature="mfcc")
         assert expected in feature_paths
 
     def test_no_files_raises(self, tree: BIDSTree):
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(FileNotFoundError, match="No matching feature files"):
             enc._discover_features(SUB)
 
     def test_duplicate_feature_file_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
         tree.add_feature("mfcc", run="1", subdir="sub")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Multiple feature files"):
             enc._discover_features(SUB)
 
@@ -94,57 +94,22 @@ class TestDiscoverFeatures:
         tree.add_feature("mfcc", run="1")
         tree.add_feature("mfcc", run="2")
         tree.add_feature("clip", run="1")
-        enc = make_encoding(tree, ["mfcc", "clip"])
+        enc = _make_encoding(tree, ["mfcc", "clip"])
         with pytest.raises(FileNotFoundError, match="Missing feature=clip"):
             enc._discover_features(SUB)
-
-    def test_semantic_entity_filter_narrows_results(self, tree: BIDSTree):
-        tree.add_feature("mfcc", block="a")
-        tree.add_feature("mfcc", block="b")
-        enc = make_encoding(tree, ["mfcc"], bids_filters=["block-a"])
-        feature_paths = enc._discover_features(SUB)
-        assert {k.cell.get("block") for k in feature_paths} == {"a"}
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", task="rest", run="1")
         tree.add_feature("mfcc", task="conv", run="2")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
             enc._discover_features(SUB)
 
-    def test_acquisition_entities_not_required_on_features(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        enc = make_encoding(tree, ["mfcc"], bids_filters=["desc-preproc"])
-        feature_paths = enc._discover_features(SUB)
-        expected = FeatureKey(cell=CellKey(run="1"), feature="mfcc")
-        assert expected in feature_paths
-
-    def test_mixed_segmented_unsegmented_runs_raise(self, tree: BIDSTree):
+    def test_mixed_segmented_unsegmented_runs_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1", block="1")
         tree.add_feature("mfcc", run="2")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent feature file schemas"):
-            enc._discover_features(SUB)
-
-    def test_typo_filter_entity_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        enc = make_encoding(tree, ["mfcc"], bids_filters=["typo-foo"])
-        with pytest.raises(ValueError, match="typo"):
-            enc._discover_features(SUB)
-
-    def test_absent_common_entity_filter_raises(self, tree: BIDSTree):
-        # ses not on any file — filter can't match, entity check fires
-        tree.add_feature("mfcc", run="1")
-        enc = make_encoding(tree, ["mfcc"], bids_filters=["ses-99"])
-        with pytest.raises(ValueError, match="ses"):
-            enc._discover_features(SUB)
-
-    def test_valid_entity_wrong_value_gives_file_not_found(self, tree: BIDSTree):
-        # block is on files — filter entity is valid, just no match for block-99
-        tree.add_feature("mfcc", block="1")
-        tree.add_feature("mfcc", block="2")
-        enc = make_encoding(tree, ["mfcc"], bids_filters=["block-99"])
-        with pytest.raises(FileNotFoundError):
             enc._discover_features(SUB)
 
     def test_schema_error_fires_before_coverage_error(self, tree: BIDSTree):
@@ -152,34 +117,41 @@ class TestDiscoverFeatures:
         tree.add_feature("mfcc", run="1", block="1")
         tree.add_feature("mfcc", run="2")
         tree.add_feature("clip", run="1", block="1")
-        enc = make_encoding(tree, ["mfcc", "clip"])
+        enc = _make_encoding(tree, ["mfcc", "clip"])
         with pytest.raises(ValueError, match="Inconsistent feature file schemas"):
             enc._discover_features(SUB)
+
+    def test_bids_filters_not_applied_at_discovery(self, tree: BIDSTree):
+        tree.add_feature("mfcc", run="1")
+        tree.add_feature("mfcc", run="2")
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
+        feature_paths = enc._discover_features(SUB)
+        assert len(feature_paths) == 2
 
 
 class TestDiscoverBold:
     def test_returns_expected_keys(self, tree: BIDSTree):
         tree.add_bold(run="1")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses=None, run="1") in bold_metas
 
     def test_no_files_raises(self, tree: BIDSTree):
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(FileNotFoundError, match="No BOLD files"):
             enc._discover_bold(SUB)
 
     def test_duplicate_bold_raises(self, tree: BIDSTree):
         tree.add_bold(run="1")
         tree.add_bold(run="1", subdir="sub")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Duplicate BOLD"):
             enc._discover_bold(SUB)
 
     def test_cross_session_runs_distinguished(self, tree: BIDSTree):
         tree.add_bold(ses="1", run="1")
         tree.add_bold(ses="2", run="1")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses="1", run="1") in bold_metas
         assert BoldKey(ses="2", run="1") in bold_metas
@@ -187,28 +159,28 @@ class TestDiscoverBold:
     def test_bold_siblings_excluded(self, tree: BIDSTree):
         tree.add_bold(run="1")
         tree.add_bold_siblings(run="1")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_wrong_space_bold_excluded(self, tree: BIDSTree):
         tree.add_bold(run="1", space="MNI152NLin6Asym")
         tree.add_bold(run="1", space="T1w")
-        enc = make_encoding(tree, ["mfcc"], bold_space="MNI152NLin6Asym")
+        enc = _make_encoding(tree, ["mfcc"], bold_space="MNI152NLin6Asym")
         bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_inconsistent_tr_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_bold(run="2", tr=1.5)
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent repetition times"):
             enc._discover_bold(SUB)
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
         tree.add_bold(task="rest", run="1")
         tree.add_bold(task="conv", run="2")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
             enc._discover_bold(SUB)
 
@@ -220,16 +192,16 @@ class TestDiscoverBold:
             )
             (tree.bold_dir / f"{stem}.nii.gz").touch()
             (tree.bold_dir / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="acq"):
             enc._discover_bold(SUB)
 
     def test_no_events_gives_no_segments(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.segments == []
+        bold_meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert bold_meta.segments == []
 
     def test_structural_entity_slices_parsed(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -240,15 +212,15 @@ class TestDiscoverBold:
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert len(meta.segments) == 2
-        assert meta.segments[0].entity == "block"
-        assert meta.segments[0].value == "1"
-        assert meta.segments[0].slice == slice(0, 50)
-        assert meta.segments[1].value == "2"
-        assert meta.segments[1].slice == slice(50, 100)
+        bold_meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert len(bold_meta.segments) == 2
+        assert bold_meta.segments[0].entity == "block"
+        assert bold_meta.segments[0].value == "1"
+        assert bold_meta.segments[0].slice == slice(0, 50)
+        assert bold_meta.segments[1].value == "2"
+        assert bold_meta.segments[1].slice == slice(50, 100)
 
     def test_multiple_kv_entities_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -259,7 +231,7 @@ class TestDiscoverBold:
                 {"trial_type": "trial-1", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="multiple BIDS key-value entities"):
             enc._discover_bold(SUB)
 
@@ -272,11 +244,11 @@ class TestDiscoverBold:
                 {"trial_type": "block", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="also appears as a flat label"):
             enc._discover_bold(SUB)
 
-    def test_duplicate_segment_values_raise(self, tree: BIDSTree):
+    def test_duplicate_segment_values_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -285,11 +257,11 @@ class TestDiscoverBold:
                 {"trial_type": "block-1", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="appears more than once"):
             enc._discover_bold(SUB)
 
-    def test_overlapping_slices_raise(self, tree: BIDSTree):
+    def test_overlapping_slices_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -298,7 +270,7 @@ class TestDiscoverBold:
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="overlap"):
             enc._discover_bold(SUB)
 
@@ -311,22 +283,20 @@ class TestDiscoverBold:
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert len(meta.segments) == 2
-        assert meta.segments[0].slice == slice(5, 50)
+        bold_meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert len(bold_meta.segments) == 2
+        assert bold_meta.segments[0].slice == slice(5, 50)
 
     def test_hyphen_free_trial_type_ignored(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
-        events_path = (
-            tree.bold_dir / f"sub-{SUB}_task-{TASK}_run-1_events.tsv"
-        )
+        events_path = tree.bold_dir / f"sub-{SUB}_task-{TASK}_run-1_events.tsv"
         events_path.write_text("trial_type\tonset\tduration\nrest\t0.0\t100.0\n")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert meta.segments == []
+        bold_meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert bold_meta.segments == []
 
     def test_kv_entity_with_gap_passes(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -337,10 +307,10 @@ class TestDiscoverBold:
                 {"trial_type": "block-2", "onset": 120.0, "duration": 80.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert len(meta.segments) == 2
+        bold_meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert len(bold_meta.segments) == 2
 
     def test_flat_labels_alongside_segments_ignored(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -352,11 +322,11 @@ class TestDiscoverBold:
                 {"trial_type": "fixation", "onset": 0.0, "duration": 10.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        meta = bold_metas[BoldKey(ses=None, run="1")]
-        assert len(meta.segments) == 2
-        assert meta.segments[0].entity == "block"
+        bold_meta = bold_metas[BoldKey(ses=None, run="1")]
+        assert len(bold_meta.segments) == 2
+        assert bold_meta.segments[0].entity == "block"
 
     def test_runs_disagree_on_segment_entity_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -375,7 +345,7 @@ class TestDiscoverBold:
                 {"trial_type": "trial-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="disagree on segment entity"):
             enc._discover_bold(SUB)
 
@@ -389,7 +359,7 @@ class TestDiscoverBold:
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="disagree on segment entity"):
             enc._discover_bold(SUB)
 
@@ -423,81 +393,81 @@ class TestDiscoverBold:
             },
         )
 
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="disagree on segment metadata schema"):
             enc._discover_bold(SUB)
 
     def test_all_unsegmented_passes(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_bold(run="2", tr=2.0)
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
-        assert all(meta.segments == [] for meta in bold_metas.values())
+        assert all(bold_meta.segments == [] for bold_meta in bold_metas.values())
+
+    def test_bids_filters_not_applied_at_discovery(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(run="2", tr=2.0)
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
+        bold_metas = enc._discover_bold(SUB)
+        assert len(bold_metas) == 2
 
 
-class TestValidateAlignment:
-    def test_valid_alignment_passes(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        tree.add_bold(run="1")
-        enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(SUB)
-        bold_metas = enc._discover_bold(SUB)
-        enc._validate_alignment(feature_paths, bold_metas)
-
-    def test_cross_file_task_invariance_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", task="rest", run="1")
-        tree.add_bold(task="conv", run="1")
-        enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(SUB)
-        bold_metas = enc._discover_bold(SUB)
-        with pytest.raises(ValueError, match="task"):
-            enc._validate_alignment(feature_paths, bold_metas)
-
-    def test_bold_without_features_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        tree.add_bold(run="1")
-        tree.add_bold(run="2")
-        enc = make_encoding(tree, ["mfcc"])
-        feature_paths = enc._discover_features(SUB)
-        bold_metas = enc._discover_bold(SUB)
-        with pytest.raises(FileNotFoundError, match="No feature files found for BOLD"):
-            enc._validate_alignment(feature_paths, bold_metas)
+class TestResolveCellKeys:
+    # Orphan check (feature cell has no matching BOLD run)
 
     def test_features_without_bold_raises(self, tree: BIDSTree):
         tree.add_feature("mfcc", run="1")
         tree.add_feature("mfcc", run="2")
         tree.add_bold(run="1")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="No BOLD file found for features"):
-            enc._validate_alignment(feature_paths, bold_metas)
+            enc._resolve_cell_keys(feature_paths, bold_metas)
 
-    def test_multiple_bold_gaps_reports_count(self, tree: BIDSTree):
+    def test_multiple_features_without_bold_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
             tree.add_feature("mfcc", run=run)
-            tree.add_bold(run=run)
-        tree.add_bold(run="4")
-        tree.add_bold(run="5")
-        enc = make_encoding(tree, ["mfcc"])
+        tree.add_bold(run="1")
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="other coverage gaps"):
-            enc._validate_alignment(feature_paths, bold_metas)
+            enc._resolve_cell_keys(feature_paths, bold_metas)
 
-    def test_multiple_feature_gaps_reports_count(self, tree: BIDSTree):
-        for run in ("1", "2", "3"):
-            tree.add_feature("mfcc", run=run)
-            tree.add_bold(run=run)
-        tree.add_feature("mfcc", run="4")
-        tree.add_feature("mfcc", run="5")
-        enc = make_encoding(tree, ["mfcc"])
+    # Unsegmented run cases
+
+    def test_unsegmented_run_single_cell_passes(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_feature("mfcc", run="1")
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        with pytest.raises(FileNotFoundError, match="other coverage gaps"):
-            enc._validate_alignment(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        assert len(feature_paths) == 1
 
-    def test_segmented_valid_cells_pass(self, tree: BIDSTree):
+    def test_unsegmented_run_multiple_cells_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
+        tree.add_feature("mfcc", run="1", trial="1")
+        tree.add_feature("mfcc", run="1", trial="2")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        with pytest.raises(ValueError, match="unsegmented but has 2 feature cells"):
+            enc._resolve_cell_keys(feature_paths, bold_metas)
+
+    def test_extra_entity_on_unsegmented_run_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
+        tree.add_feature("mfcc", run="1", trial="1")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        with pytest.raises(ValueError, match="only ses and run are valid"):
+            enc._resolve_cell_keys(feature_paths, bold_metas)
+
+    # Segmented run cases
+
+    def test_valid_segmented_cells_pass(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
         tree.add_events(
             run="1",
@@ -508,10 +478,11 @@ class TestValidateAlignment:
         )
         tree.add_feature("mfcc", run="1", block="1")
         tree.add_feature("mfcc", run="1", block="2")
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        enc._validate_alignment(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        assert len(feature_paths) == 2
 
     def test_cell_missing_segment_entity_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -523,11 +494,11 @@ class TestValidateAlignment:
             ],
         )
         tree.add_feature("mfcc", run="1")  # no block entity on the filename
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="missing segment entity"):
-            enc._validate_alignment(feature_paths, bold_metas)
+            enc._resolve_cell_keys(feature_paths, bold_metas)
 
     def test_cell_value_not_in_events_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -539,30 +510,329 @@ class TestValidateAlignment:
             ],
         )
         tree.add_feature("mfcc", run="1", block="3")  # block-3 not in events
-        enc = make_encoding(tree, ["mfcc"])
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="not found in events"):
-            enc._validate_alignment(feature_paths, bold_metas)
+            enc._resolve_cell_keys(feature_paths, bold_metas)
 
-    def test_unsegmented_run_multiple_cells_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
-        tree.add_feature("mfcc", run="1", trial="1")
-        tree.add_feature("mfcc", run="1", trial="2")
-        enc = make_encoding(tree, ["mfcc"])
+    def test_extra_entity_on_segmented_run_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+            ],
+        )
+        tree.add_feature("mfcc", run="1", block="1", extra="foo")
+        enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        with pytest.raises(ValueError, match="unsegmented but has 2 feature cells"):
-            enc._validate_alignment(feature_paths, bold_metas)
+        with pytest.raises(ValueError, match="absent from events.json"):
+            enc._resolve_cell_keys(feature_paths, bold_metas)
 
-    def test_apparent_segment_entity_without_events_passes_silently(
+    # Metadata merge cases (filename × sidecar)
+
+    def test_sidecar_only_metadata_merged_onto_cell_key(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "R"},
+                    {"block": "2", "cond": "L"},
+                ]
+            },
+        )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        cell_cond_values = {
+            feature_key.cell.get("cond") for feature_key in feature_paths
+        }
+        assert cell_cond_values == {"R", "L"}
+
+    def test_filename_value_agrees_with_sidecar_passes(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+            ],
+            events_json={"Segments": [{"block": "1", "cond": "R"}]},
+        )
+        tree.add_feature("mfcc", run="1", block="1", cond="R")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        assert next(iter(feature_paths)).cell.get("cond") == "R"
+
+    def test_filename_value_disagrees_with_sidecar_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+            ],
+            events_json={"Segments": [{"block": "1", "cond": "R"}]},
+        )
+        tree.add_feature("mfcc", run="1", block="1", cond="L")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        with pytest.raises(ValueError, match="disagree on"):
+            enc._resolve_cell_keys(feature_paths, bold_metas)
+
+
+class TestApplyFilters:
+    def test_no_filters_returns_unchanged(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        filtered_features, filtered_bold = enc._apply_filters(feature_paths, bold_metas)
+        assert filtered_features == feature_paths
+        assert filtered_bold == bold_metas
+
+    def test_filter_narrows_features(self, tree: BIDSTree):
+        for run in ("1", "2"):
+            tree.add_bold(run=run, tr=2.0)
+            tree.add_events(
+                run=run,
+                rows=[
+                    {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                    {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+                ],
+            )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature("mfcc", run="2", block="1")
+        tree.add_feature("mfcc", run="2", block="2")
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        assert all(feature_key.cell.get("run") == "1" for feature_key in feature_paths)
+        assert all(bold_key.run == "1" for bold_key in bold_metas)
+
+    def test_or_within_entity_and_across_entities(self, tree: BIDSTree):
+        for ses, run in (("1", "1"), ("1", "2"), ("2", "1")):
+            tree.add_bold(ses=ses, run=run, tr=2.0)
+            tree.add_events(
+                ses=ses,
+                run=run,
+                rows=[
+                    {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                ],
+            )
+            tree.add_feature("mfcc", ses=ses, run=run, block="1")
+        enc = _make_encoding(
+            tree,
+            ["mfcc"],
+            bids_filters=["ses-1", "run-1", "run-2"],  # ses-1 AND (run-1 OR run-2)
+        )
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        assert BoldKey(ses="1", run="1") in bold_metas
+        assert BoldKey(ses="1", run="2") in bold_metas
+        assert BoldKey(ses="2", run="1") not in bold_metas
+
+    def test_filter_on_bold_only_entity_skipped_on_features(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        enc = _make_encoding(
+            tree,
+            ["mfcc"],
+            bids_filters=["desc-preproc"],  # on BOLD filenames but not on CellKey
+        )
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        assert len(feature_paths) == 2
+        assert len(bold_metas) == 1
+
+    def test_filter_on_cell_only_entity_skipped_on_bold(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+            events_json={
+                "Segments": [
+                    {"block": "1", "cond": "R"},
+                    {"block": "2", "cond": "L"},
+                ]
+            },
+        )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        enc = _make_encoding(
+            tree,
+            ["mfcc"],
+            bids_filters=["cond-R"],  # on CellKey but not on BOLD filenames
+        )
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        assert len(feature_paths) == 1
+        assert len(bold_metas) == 1
+
+    def test_typo_filter_entity_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", tr=2.0)
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["typo-foo"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        with pytest.raises(ValueError, match="typo"):
+            enc._apply_filters(feature_paths, bold_metas)
+
+    def test_valid_entity_wrong_value_passes_filter_raises_at_coverage(
         self, tree: BIDSTree
     ):
-        # Blind spot: trial-1 on filename without events.tsv is indistinguishable
-        # from a descriptive tag — mismatch surfaces only as row-count errors later
         tree.add_bold(run="1", tr=2.0)
-        tree.add_feature("mfcc", run="1", trial="1")
-        enc = make_encoding(tree, ["mfcc"])
+        tree.add_events(
+            run="1",
+            rows=[
+                {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
+                {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
+            ],
+        )
+        tree.add_feature("mfcc", run="1", block="1")
+        tree.add_feature("mfcc", run="1", block="2")
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["block-99"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        enc._validate_alignment(feature_paths, bold_metas)  # does not raise
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(FileNotFoundError, match="No feature files match"):
+            enc._validate_coverage(feature_paths, bold_metas)
+
+
+class TestValidateCoverage:
+    def test_valid_alignment_passes(self, tree: BIDSTree):
+        tree.add_bold(run="1")
+        tree.add_feature("mfcc", run="1")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        enc._validate_coverage(feature_paths, bold_metas)
+
+    def test_cross_file_task_invariance_raises(self, tree: BIDSTree):
+        tree.add_bold(task="conv", run="1")
+        tree.add_feature("mfcc", task="rest", run="1")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(ValueError, match="task"):
+            enc._validate_coverage(feature_paths, bold_metas)
+
+    def test_empty_features_after_filter_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1")
+        tree.add_feature("mfcc", run="1")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(FileNotFoundError, match="No feature files match"):
+            enc._validate_coverage({}, bold_metas)
+
+    def test_empty_bold_after_filter_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1")
+        tree.add_feature("mfcc", run="1")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(FileNotFoundError, match="No BOLD files match"):
+            enc._validate_coverage(feature_paths, {})
+
+    def test_bold_without_features_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1")
+        tree.add_bold(run="2")
+        tree.add_feature("mfcc", run="1")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(FileNotFoundError, match="No feature files found for BOLD"):
+            enc._validate_coverage(feature_paths, bold_metas)
+
+    def test_features_without_bold_after_filter_raises(self, tree: BIDSTree):
+        tree.add_bold(run="1", desc="preproc")
+        tree.add_bold(run="2", desc="smooth")
+        tree.add_feature("mfcc", run="1")
+        tree.add_feature("mfcc", run="2")
+        enc = _make_encoding(
+            tree,
+            ["mfcc"],
+            bids_filters=["desc-preproc"],  # filters BOLD only (features carry no desc)
+        )
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(FileNotFoundError, match="No BOLD file found for features"):
+            enc._validate_coverage(feature_paths, bold_metas)
+
+    def test_multiple_bold_gaps_reports_count(self, tree: BIDSTree):
+        for run in ("1", "2", "3"):
+            tree.add_bold(run=run)
+            tree.add_feature("mfcc", run=run)
+        tree.add_bold(run="4")
+        tree.add_bold(run="5")
+        enc = _make_encoding(tree, ["mfcc"])
+        feature_paths = enc._discover_features(SUB)
+        bold_metas = enc._discover_bold(SUB)
+        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        with pytest.raises(FileNotFoundError, match="other coverage gaps"):
+            enc._validate_coverage(feature_paths, bold_metas)

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -423,7 +423,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="No BOLD file found for features"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_multiple_features_without_bold_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
@@ -433,7 +433,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(FileNotFoundError, match="other coverage gaps"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     # Unsegmented run cases
 
@@ -443,7 +443,7 @@ class TestResolveCellKeys:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
         assert len(feature_paths) == 1
 
     def test_unsegmented_run_multiple_cells_raises(self, tree: BIDSTree):
@@ -453,8 +453,8 @@ class TestResolveCellKeys:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        with pytest.raises(ValueError, match="unsegmented but has 2 feature cells"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+        with pytest.raises(ValueError, match="unsegmented but has 2 feature files"):
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_extra_entity_on_unsegmented_run_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
@@ -463,7 +463,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="only ses and run are valid"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     # Segmented run cases
 
@@ -481,7 +481,7 @@ class TestResolveCellKeys:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
         assert len(feature_paths) == 2
 
     def test_cell_missing_segment_entity_raises(self, tree: BIDSTree):
@@ -498,7 +498,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="missing segment entity"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_cell_value_not_in_events_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -514,7 +514,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="not found in events"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_extra_entity_on_segmented_run_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", tr=2.0)
@@ -529,7 +529,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="absent from events.json"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     # Metadata merge cases (filename × sidecar)
 
@@ -553,7 +553,7 @@ class TestResolveCellKeys:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
         cell_cond_values = {
             feature_key.cell.get("cond") for feature_key in feature_paths
         }
@@ -572,7 +572,7 @@ class TestResolveCellKeys:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
         assert next(iter(feature_paths)).cell.get("cond") == "R"
 
     def test_filename_value_disagrees_with_sidecar_raises(self, tree: BIDSTree):
@@ -589,7 +589,7 @@ class TestResolveCellKeys:
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         with pytest.raises(ValueError, match="disagree on"):
-            enc._resolve_cell_keys(feature_paths, bold_metas)
+            enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
 
 class TestApplyFilters:
@@ -607,8 +607,10 @@ class TestApplyFilters:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        filtered_features, filtered_bold = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        filtered_features, filtered_bold = enc._apply_filters(
+            SUB, feature_paths, bold_metas
+        )
         assert filtered_features == feature_paths
         assert filtered_bold == bold_metas
 
@@ -629,8 +631,8 @@ class TestApplyFilters:
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         assert all(feature_key.cell.get("run") == "1" for feature_key in feature_paths)
         assert all(bold_key.run == "1" for bold_key in bold_metas)
 
@@ -652,8 +654,8 @@ class TestApplyFilters:
         )
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         assert BoldKey(ses="1", run="1") in bold_metas
         assert BoldKey(ses="1", run="2") in bold_metas
         assert BoldKey(ses="2", run="1") not in bold_metas
@@ -676,8 +678,8 @@ class TestApplyFilters:
         )
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         assert len(feature_paths) == 2
         assert len(bold_metas) == 1
 
@@ -705,8 +707,8 @@ class TestApplyFilters:
         )
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         assert len(feature_paths) == 1
         assert len(bold_metas) == 1
 
@@ -724,9 +726,9 @@ class TestApplyFilters:
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["typo-foo"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
         with pytest.raises(ValueError, match="typo"):
-            enc._apply_filters(feature_paths, bold_metas)
+            enc._apply_filters(SUB, feature_paths, bold_metas)
 
     def test_valid_entity_wrong_value_passes_filter_raises_at_coverage(
         self, tree: BIDSTree
@@ -744,10 +746,10 @@ class TestApplyFilters:
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["block-99"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(FileNotFoundError, match="No feature files match"):
-            enc._validate_coverage(feature_paths, bold_metas)
+            enc._validate_coverage(SUB, feature_paths, bold_metas)
 
 
 class TestValidateCoverage:
@@ -757,9 +759,9 @@ class TestValidateCoverage:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
-        enc._validate_coverage(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
+        enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_cross_file_task_invariance_raises(self, tree: BIDSTree):
         tree.add_bold(task="conv", run="1")
@@ -767,10 +769,10 @@ class TestValidateCoverage:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(ValueError, match="task"):
-            enc._validate_coverage(feature_paths, bold_metas)
+            enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_empty_features_after_filter_raises(self, tree: BIDSTree):
         tree.add_bold(run="1")
@@ -778,10 +780,10 @@ class TestValidateCoverage:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(FileNotFoundError, match="No feature files match"):
-            enc._validate_coverage({}, bold_metas)
+            enc._validate_coverage(SUB, {}, bold_metas)
 
     def test_empty_bold_after_filter_raises(self, tree: BIDSTree):
         tree.add_bold(run="1")
@@ -789,10 +791,10 @@ class TestValidateCoverage:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(FileNotFoundError, match="No BOLD files match"):
-            enc._validate_coverage(feature_paths, {})
+            enc._validate_coverage(SUB, feature_paths, {})
 
     def test_bold_without_features_raises(self, tree: BIDSTree):
         tree.add_bold(run="1")
@@ -801,10 +803,10 @@ class TestValidateCoverage:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(FileNotFoundError, match="No feature files found for BOLD"):
-            enc._validate_coverage(feature_paths, bold_metas)
+            enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_features_without_bold_after_filter_raises(self, tree: BIDSTree):
         tree.add_bold(run="1", desc="preproc")
@@ -818,10 +820,10 @@ class TestValidateCoverage:
         )
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(FileNotFoundError, match="No BOLD file found for features"):
-            enc._validate_coverage(feature_paths, bold_metas)
+            enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_multiple_bold_gaps_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
@@ -832,7 +834,7 @@ class TestValidateCoverage:
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
-        feature_paths = enc._resolve_cell_keys(feature_paths, bold_metas)
-        feature_paths, bold_metas = enc._apply_filters(feature_paths, bold_metas)
+        feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
+        feature_paths, bold_metas = enc._apply_filters(SUB, feature_paths, bold_metas)
         with pytest.raises(FileNotFoundError, match="other coverage gaps"):
-            enc._validate_coverage(feature_paths, bold_metas)
+            enc._validate_coverage(SUB, feature_paths, bold_metas)


### PR DESCRIPTION
## Summary

- Replace the implicit `Partitioning` concept with an explicit `Segment` dataclass in `bold.py`; consolidate TR, `events.tsv`, and `events.json` loading into `load_bold_meta`
- Drop the tiling requirement: segments can start late, have gaps, or cover only part of a run
- Introduce `SegmentMetadata` in `events.json` for per-segment metadata; validated and merged onto each `CellKey` during cell resolution; split `load_events` into `load_events_tsv` + `load_events_json` backed by a shared `_resolve_run_sidecar`
- Refactor `_validate_alignment` into `_resolve_cell_keys`, `_apply_filters`, and `_validate_coverage`: cell resolution and filtering now run on enriched cells post-discovery rather than pre-filtering by entity type
- Move `bids_filters` application to `_apply_filters`, which skips filter keys absent from one side and raises on keys absent from both (typo detection); remove the old BOLD-exclusive entity routing logic
- Expand `CellKey.EXCLUDE` to cover all BOLD-derivative entities (`desc`, `res`, `den`, `echo`, `acq`, `ce`, `rec`, `dir`)
- Add `BIDS_ENTITY_KEY_RE` / `BIDS_ENTITY_VALUE_RE` to `bids.py` for finer per-component validation
- Include `space` in error location strings via `_format_loc`
