### PR TITLE
Add `BIDSLayout` as single authority for BIDS paths

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -47,3 +47,4 @@ AI agents alike. Agent-agnostic by design.
 | Consuming fMRIPrep outputs             | `external/fmriprep.md`                              |
 | Introducing a new segment entity       | `decisions/semantic-entity.md`, `external/bids.md`  |
 | Changing segment metadata convention   | `decisions/segment-metadata.md`, `modules/encoding.md` |
+| Locating files in the BIDS tree        | `decisions/layout.md`, `external/bids.md`           |

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -19,22 +19,22 @@ reads, `resample_feature` handles TR alignment.
 ## Naming
 
 Feature files carry **stimulus-side identity entities** from the source BOLD (`sub`, `ses`,
-`task`, `run`), the segment entity value (e.g. `trial-1`), and hypline's own `feature` entity:
+`task`, `run`), the segment entity value (e.g. `trial-1`), and hypline's own `feat` entity:
 
 ```
-sub-01_ses-01_task-movie_run-1_trial-1_feature-clip.parquet   # with sessions
-sub-01_task-movie_run-1_trial-1_feature-clip.parquet           # sessionless
+sub-01_ses-01_task-movie_run-1_trial-1_feat-clip.parquet   # with sessions
+sub-01_task-movie_run-1_trial-1_feat-clip.parquet           # sessionless
 ```
 
 Feature files live under `features/sub-XX/[ses-YY/]<kind>/` where `<kind>` matches the
-`feature-<kind>` entity on the filename (e.g. `features/sub-01/ses-01/phonemic/`). See
+`feat-<kind>` entity on the filename (e.g. `features/sub-01/ses-01/phonemic/`). See
 [layout.md](layout.md) for the full root tree.
 
 Feature files carry only structural identity — descriptive attributes (condition, stimulus
 item, etc.) live in `events.json` under `SegmentMetadata` and are joined at enrichment time. Do not
 put descriptive entities on feature filenames; they belong in the sidecar.
 
-Feature files do **not** carry a BIDS suffix (e.g., `_bold`). The `feature-<label>` entity
+Feature files do **not** carry a BIDS suffix (e.g., `_bold`). The `feat-<label>` entity
 already identifies the data type; a suffix would be redundant, and no standard BIDS suffix
 exists for derived feature files. Feature path validation rejects any path with a suffix.
 
@@ -52,7 +52,7 @@ feature files are not required to mirror them.
 
 Excluded from `CellKey` (`CellKey.EXCLUDE`): `sub`, `task`, `acq`, `ce`, `rec`, `dir`
 (invariant within a training call), `desc`, `res`, `den`, `echo` (BOLD image-variant
-derivatives), `space`, `feature` (orthogonal axes). Entities are present or absent — no
+derivatives), `space`, `feat` (orthogonal axes). Entities are present or absent — no
 `None` sentinel. Equality and hashing are order-independent.
 
 CV splits are expressed by querying `CellKey` entities:
@@ -92,7 +92,7 @@ don't map 1:1 to BOLD TRs.
 ## Parquet metadata
 
 Feature files carry a `hypline` JSON blob in the Parquet footer. Hypline reserves
-keys for feature-type identity (validated against the `feature` filename entity on
+keys for feature-type identity (validated against the `feat` filename entity on
 read) and package-version provenance; callers must not supply them.
 
 Caller-supplied keys should let a consumer reproduce the array — any generator

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -25,6 +25,10 @@ Feature files carry **stimulus-side identity entities** from the source BOLD (`s
 sub-01_ses-01_task-movie_run-1_trial-1_feature-clip.parquet
 ```
 
+Feature files live under `features/sub-XX/ses-YY/<kind>/` where `<kind>` matches the
+`feature-<kind>` entity on the filename (e.g. `features/sub-01/ses-01/phonemic/`). See
+[layout.md](layout.md) for the full root tree.
+
 Feature files carry only structural identity — descriptive attributes (condition, stimulus
 item, etc.) live in `events.json` under `SegmentMetadata` and are joined at enrichment time. Do not
 put descriptive entities on feature filenames; they belong in the sidecar.

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -22,10 +22,11 @@ Feature files carry **stimulus-side identity entities** from the source BOLD (`s
 `task`, `run`), the segment entity value (e.g. `trial-1`), and hypline's own `feature` entity:
 
 ```
-sub-01_ses-01_task-movie_run-1_trial-1_feature-clip.parquet
+sub-01_ses-01_task-movie_run-1_trial-1_feature-clip.parquet   # with sessions
+sub-01_task-movie_run-1_trial-1_feature-clip.parquet           # sessionless
 ```
 
-Feature files live under `features/sub-XX/ses-YY/<kind>/` where `<kind>` matches the
+Feature files live under `features/sub-XX/[ses-YY/]<kind>/` where `<kind>` matches the
 `feature-<kind>` entity on the filename (e.g. `features/sub-01/ses-01/phonemic/`). See
 [layout.md](layout.md) for the full root tree.
 

--- a/notes/decisions/feature-files.md
+++ b/notes/decisions/feature-files.md
@@ -26,9 +26,7 @@ sub-01_ses-01_task-movie_run-1_trial-1_feat-clip.parquet   # with sessions
 sub-01_task-movie_run-1_trial-1_feat-clip.parquet           # sessionless
 ```
 
-Feature files live under `features/sub-XX/[ses-YY/]<kind>/` where `<kind>` matches the
-`feat-<kind>` entity on the filename (e.g. `features/sub-01/ses-01/phonemic/`). See
-[layout.md](layout.md) for the full root tree.
+Feature files live under `features/` — see [layout.md](layout.md) for the root tree.
 
 Feature files carry only structural identity — descriptive attributes (condition, stimulus
 item, etc.) live in `events.json` under `SegmentMetadata` and are joined at enrichment time. Do not

--- a/notes/decisions/layout.md
+++ b/notes/decisions/layout.md
@@ -23,28 +23,20 @@ CLI commands take a single `<bids_root>`; path resolution is centralized.
 Two terms name directory levels below `sub-XX/ses-YY/` and must not be conflated:
 
 - **`datatype`** — BIDS spec directory (`func` / `anat` / `dwi` / ...). Applies to raw BIDS and fmriprep areas.
-- **`kind`** — hypline category. For `stimuli/`: `audio`, `transcript`. For `features/`: `phonemic`, `semantic`. Matches the `feat-<kind>` entity on feature filenames.
+- **`kind`** — hypline category. For `stimuli/`: `audio`, `transcript` (matches the `stim-<kind>` entity on stimulus filenames). For `features/`: `phonemic`, `semantic` (matches the `feat-<kind>` entity on feature filenames).
 
-## Cleaned BOLD contract
+## Post-processed BOLD placement
 
-Cleaned BOLD lives **in-tree** under the fmriprep derivatives:
+Post-processed BOLD (e.g. cleaned) lives in-tree alongside fmriprep outputs:
 
 ```
 <root>/derivatives/fmriprep/sub-XX/ses-YY/func/
-    sub-XX_ses-YY_..._desc-clean_bold.nii.gz
+    sub-XX_ses-YY_..._desc-<label>_bold.nii.gz
 ```
 
-Any tool that writes cleaned BOLD must write to this location. The historical
-convention (sibling tree `<fmriprep_dir>_cleaned/`) is deprecated and must not
-be used for new writes.
-
-## Area presence guarantees
-
-- `sub-XX/`, `derivatives/fmriprep/` — assumed present; commands that require
-  them raise if absent.
-- `stimuli/`, `features/` — may be absent on first run; the command that
-  creates outputs (`featuregen`, `transcribe`) materializes the directory before
-  writing.
+Post-processing is a continuation of the fmriprep pipeline and shares its
+identity entities, so outputs belong in the same derivatives tree rather than
+a parallel one.
 
 See [../external/bids.md](../external/bids.md) for BIDS entity conventions.
 See [feature-files.md](feature-files.md) for feature file naming and path conventions.

--- a/notes/decisions/layout.md
+++ b/notes/decisions/layout.md
@@ -23,7 +23,7 @@ CLI commands take a single `<root_dir>`; path resolution is centralized.
 Two terms name directory levels below `sub-XX/ses-YY/` and must not be conflated:
 
 - **`datatype`** — BIDS spec directory (`func` / `anat` / `dwi` / ...). Applies to raw BIDS and fmriprep areas.
-- **`kind`** — hypline category. For `stimuli/`: `audio`, `transcript`. For `features/`: `phonemic`, `semantic`. Matches the `feature-<kind>` entity on feature filenames.
+- **`kind`** — hypline category. For `stimuli/`: `audio`, `transcript`. For `features/`: `phonemic`, `semantic`. Matches the `feat-<kind>` entity on feature filenames.
 
 ## Cleaned BOLD contract
 

--- a/notes/decisions/layout.md
+++ b/notes/decisions/layout.md
@@ -16,7 +16,7 @@ Directory contract for the hypline-flavored BIDS root tree.
 `<datatype>` / `<kind>` directly under `sub-XX/`. Path resolution handles both.
 
 `stimuli/` and `features/` are hypline extensions — not in the BIDS spec.
-CLI commands take a single `<root_dir>`; path resolution is centralized.
+CLI commands take a single `<bids_root>`; path resolution is centralized.
 
 ## Vocabulary
 

--- a/notes/decisions/layout.md
+++ b/notes/decisions/layout.md
@@ -1,0 +1,47 @@
+# Hypline root layout
+
+Directory contract for the hypline-flavored BIDS root tree.
+
+## Tree structure
+
+```
+<root>/
+├── sub-XX/ses-YY/<datatype>/                        # raw BIDS
+├── derivatives/fmriprep/sub-XX/ses-YY/<datatype>/   # fmriprep outputs
+├── stimuli/sub-XX/ses-YY/<kind>/                    # audio, transcript, ...
+└── features/sub-XX/ses-YY/<kind>/                   # phonemic, semantic, ...
+```
+
+`stimuli/` and `features/` are hypline extensions — not in the BIDS spec.
+CLI commands take a single `<root_dir>`; path resolution is centralized.
+
+## Vocabulary
+
+Two terms name directory levels below `sub-XX/ses-YY/` and must not be conflated:
+
+- **`datatype`** — BIDS spec directory (`func` / `anat` / `dwi` / ...). Applies to raw BIDS and fmriprep areas.
+- **`kind`** — hypline category. For `stimuli/`: `audio`, `transcript`. For `features/`: `phonemic`, `semantic`. Matches the `feature-<kind>` entity on feature filenames.
+
+## Cleaned BOLD contract
+
+Cleaned BOLD lives **in-tree** under the fmriprep derivatives:
+
+```
+<root>/derivatives/fmriprep/sub-XX/ses-YY/func/
+    sub-XX_ses-YY_..._desc-clean_bold.nii.gz
+```
+
+Any tool that writes cleaned BOLD must write to this location. The historical
+convention (sibling tree `<fmriprep_dir>_cleaned/`) is deprecated and must not
+be used for new writes.
+
+## Area presence guarantees
+
+- `sub-XX/`, `derivatives/fmriprep/` — assumed present; commands that require
+  them raise if absent.
+- `stimuli/`, `features/` — may be absent on first run; the command that
+  creates outputs (`featuregen`, `transcribe`) materializes the directory before
+  writing.
+
+See [../external/bids.md](../external/bids.md) for BIDS entity conventions.
+See [feature-files.md](feature-files.md) for feature file naming and path conventions.

--- a/notes/decisions/layout.md
+++ b/notes/decisions/layout.md
@@ -6,11 +6,14 @@ Directory contract for the hypline-flavored BIDS root tree.
 
 ```
 <root>/
-├── sub-XX/ses-YY/<datatype>/                        # raw BIDS
-├── derivatives/fmriprep/sub-XX/ses-YY/<datatype>/   # fmriprep outputs
-├── stimuli/sub-XX/ses-YY/<kind>/                    # audio, transcript, ...
-└── features/sub-XX/ses-YY/<kind>/                   # phonemic, semantic, ...
+├── sub-XX/[ses-YY/]<datatype>/                        # raw BIDS
+├── derivatives/fmriprep/sub-XX/[ses-YY/]<datatype>/   # fmriprep outputs
+├── stimuli/sub-XX/[ses-YY/]<kind>/                    # audio, transcript, ...
+└── features/sub-XX/[ses-YY/]<kind>/                   # phonemic, semantic, ...
 ```
+
+`ses-YY/` is present only for datasets with sessions; sessionless datasets nest
+`<datatype>` / `<kind>` directly under `sub-XX/`. Path resolution handles both.
 
 `stimuli/` and `features/` are hypline extensions — not in the BIDS spec.
 CLI commands take a single `<root_dir>`; path resolution is centralized.

--- a/notes/decisions/segment-metadata.md
+++ b/notes/decisions/segment-metadata.md
@@ -39,7 +39,7 @@ Within a single events.json (enforced in `bold.load_bold_meta`):
 - Entity-keyed Levels entries match events.tsv segment `entity-value` keys exactly (set equality).
 - All entries share identical metadata key sets (schema invariance).
 - No metadata key collides with BOLD identity entities (`sub`, `ses`, `task`, `acq`, `ce`,
-  `rec`, `dir`, `run`). Encoding-pipeline reserved keys (`space`, `feature`) are rejected
+  `rec`, `dir`, `run`). Encoding-pipeline reserved keys (`space`, `feat`) are rejected
   by `CellKey.EXCLUDE` at `CellKey.__init__` during `_discover_features` — keeping
   `bold.py` agnostic of encoding-pipeline concerns.
 

--- a/notes/external/bids.md
+++ b/notes/external/bids.md
@@ -45,6 +45,10 @@ events.tsv (e.g. `block`, `trial`) are inferred as the segment entity at discove
 exactly one entity name is allowed per run. See
 [../decisions/semantic-entity.md](../decisions/semantic-entity.md).
 
+Hypline extends the BIDS root with two non-standard areas (`stimuli/`, `features/`) that
+follow the same `sub-XX/ses-YY/<kind>/` nesting. See
+[../decisions/layout.md](../decisions/layout.md).
+
 ## `trial_type.Levels` for segment metadata
 
 BIDS allows `trial_type.Levels` in `events.json` as a dict mapping trial type labels to

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -81,13 +81,13 @@ intentional — fMRIPrep derivatives are often organized in per-subject subdirec
 All user-supplied `bids_filters` are applied post-resolution in `_apply_filters` against
 resolved `CellKey`s (features) and BOLD filename entities (BOLD). Neither `_discover_features`
 nor `_discover_bold` apply user filters — both use only hard-coded structural filters
-(`sub`, `feature`, `space`).
+(`sub`, `feat`, `space`).
 
 Rationale: metadata entities (e.g. `cond-R`) do not exist on filenames and cannot be routed
 to `find_files`. Applying all filters uniformly post-resolution ensures consistent behaviour
 whether the filter targets a structural entity (`ses-1`) or a descriptive one (`cond-R`).
 
-- **Reserved entities** (`sub`, `space`, `feature`): rejected at construction — use the
+- **Reserved entities** (`sub`, `space`, `feat`): rejected at construction — use the
   dedicated arguments instead.
 
 **Match semantics:** multiple filters sharing the same entity key OR-match within that group;

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -105,9 +105,6 @@ before any empty-result `FileNotFoundError`.
 
 ## Assumptions that could break
 
-- **Cleaned BOLD lives in-tree** under `derivatives/fmriprep/.../desc-clean_bold.nii.gz`.
-  The historical sibling-tree convention is deprecated. See
-  [../decisions/layout.md](../decisions/layout.md).
 - **Consistent TR across all runs** for a subject. Mixed-TR datasets would
   need per-run TR handling.
 - **Feature files mirror BOLD identity entities.** See

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -105,6 +105,9 @@ before any empty-result `FileNotFoundError`.
 
 ## Assumptions that could break
 
+- **Cleaned BOLD lives in-tree** under `derivatives/fmriprep/.../desc-clean_bold.nii.gz`.
+  The historical sibling-tree convention is deprecated. See
+  [../decisions/layout.md](../decisions/layout.md).
 - **Consistent TR across all runs** for a subject. Mixed-TR datasets would
   need per-run TR handling.
 - **Feature files mirror BOLD identity entities.** See

--- a/src/hypline/_utils.py
+++ b/src/hypline/_utils.py
@@ -11,6 +11,7 @@ def validate_dirs(*paths: str | os.PathLike[str]) -> None:
             raise FileNotFoundError(f"Directory does not exist: {path}")
 
 
+# TODO: drop after replacing all callsites with BIDSLayout
 def find_files(
     directory: str | os.PathLike[str],
     *,

--- a/src/hypline/bids.py
+++ b/src/hypline/bids.py
@@ -7,6 +7,7 @@ BIDS_ENTITY_KEY_RE = re.compile(r"^[a-z]+$")
 BIDS_ENTITY_VALUE_RE = re.compile(r"^[a-zA-Z0-9]+$")
 BIDS_ENTITY_RE = re.compile(r"^[a-z]+-[a-zA-Z0-9]+$")
 _BIDS_SUFFIX_RE = re.compile(r"^[a-zA-Z0-9]+$")
+_EXTENSION_RE = re.compile(r"^\.[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*$")
 
 
 class BIDSPath:
@@ -77,6 +78,11 @@ class BIDSPath:
             ) from None
 
     def with_entity(self, key: str, value: str) -> "BIDSPath":
+        """Return a new BIDSPath with `key` set to `value`.
+
+        Existing keys keep their position; new keys are appended. Order is
+        preserved in the filename stem of derived paths.
+        """
         entity = f"{key}-{value}"
         if not BIDS_ENTITY_RE.match(entity):
             raise ValueError(f"Invalid BIDS entity: {entity!r}")
@@ -91,6 +97,19 @@ class BIDSPath:
 
         return BIDSPath(self._path.with_name(name))
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BIDSPath):
+            return NotImplemented
+        return self._path == other._path
+
+    def __hash__(self) -> int:
+        return hash(self._path)
+
+    def __lt__(self, other: "BIDSPath") -> bool:
+        if not isinstance(other, BIDSPath):
+            return NotImplemented
+        return self._path < other._path
+
     def __repr__(self) -> str:
         return f"BIDSPath({str(self._path)!r})"
 
@@ -99,6 +118,11 @@ def validate_bids_entities(*entities: str) -> None:
     for entity in entities:
         if not BIDS_ENTITY_RE.match(entity):
             raise ValueError(f"Invalid BIDS entity: {entity!r}")
+
+
+def validate_extension(ext: str) -> None:
+    if not _EXTENSION_RE.match(ext):
+        raise ValueError(f"Invalid extension: {ext!r}")
 
 
 def validate_entity_invariance(
@@ -128,3 +152,43 @@ def normalize_bids_filters(
                 "— use the dedicated argument instead"
             )
     return filters
+
+
+def find_bids_files(
+    directory: str | os.PathLike[str],
+    ext: str,
+    *,
+    suffix: str | None = None,
+    bids_filters: list[str] | None = None,
+    recursive: bool = False,
+) -> list[BIDSPath]:
+    """Find BIDS files under `directory` matching `suffix` and `ext`.
+
+    Non-parseable filenames are silently skipped. Filters sharing a key
+    are OR'd; filters with different keys are AND'd. `recursive=True`
+    descends into subdirectories. Results are sorted by path.
+    """
+    validate_extension(ext)
+    if bids_filters:
+        validate_bids_entities(*bids_filters)
+    directory = Path(directory)
+    ends_with = f"_{suffix}{ext}" if suffix is not None else ext
+
+    groups: dict[str, list[str]] = {}
+    for entity in bids_filters or ():
+        key, _, value = entity.partition("-")
+        groups.setdefault(key, []).append(value)
+
+    files = directory.rglob("*") if recursive else directory.iterdir()
+    results: list[BIDSPath] = []
+    for f in files:
+        if not (f.is_file() and f.name.endswith(ends_with)):
+            continue
+        try:
+            bp = BIDSPath(f)
+        except ValueError:
+            continue
+        if all(bp._entities.get(k) in vals for k, vals in groups.items()):
+            results.append(bp)
+
+    return sorted(results)

--- a/src/hypline/cli/featuregen.py
+++ b/src/hypline/cli/featuregen.py
@@ -34,6 +34,7 @@ def generate_phonemic_feature(
     bids_filters: Annotated[
         str | None,
         typer.Option(
+            "--data-filters",
             help="Comma-separated BIDS entity filters (e.g., run-2,run-4,cond-G)",
             show_default=False,
         ),
@@ -44,7 +45,7 @@ def generate_phonemic_feature(
     from hypline.layout import BIDSLayout
 
     resolved_sub_ids = split_csv(sub_ids, param_hint="--sub-ids")
-    resolved_bids_filters = split_csv(bids_filters, param_hint="--bids-filters")
+    resolved_bids_filters = split_csv(bids_filters, param_hint="--data-filters")
 
     layout = BIDSLayout(bids_root)
 

--- a/src/hypline/cli/featuregen.py
+++ b/src/hypline/cli/featuregen.py
@@ -10,17 +10,10 @@ app = typer.Typer()
 
 @app.command(name="phonemic")
 def generate_phonemic_feature(
-    input_dir: Annotated[
+    bids_root: Annotated[
         Path,
         typer.Argument(
-            help="Directory containing word-level transcripts (CSV files)",
-            show_default=False,
-        ),
-    ],
-    output_dir: Annotated[
-        Path,
-        typer.Argument(
-            help="Directory to store phonemic feature data (Parquet files)",
+            help="BIDS dataset root (contains stimuli/, features/, derivatives/)",
             show_default=False,
         ),
     ],
@@ -34,9 +27,7 @@ def generate_phonemic_feature(
     sub_ids: Annotated[
         str | None,
         typer.Option(
-            help="""
-            Comma-separated subject IDs to process (e.g., 01,02); omit to process all
-            """,
+            help="Comma-separated subject IDs to process (e.g., 01,02); omit for all",
             show_default=False,
         ),
     ] = None,
@@ -49,26 +40,22 @@ def generate_phonemic_feature(
     ] = None,
 ):
     """Generate phonemic feature from word-level transcripts."""
-    from hypline.bids import BIDSPath
     from hypline.features.phonemic import PhonemicFeature
+    from hypline.layout import BIDSLayout
 
     resolved_sub_ids = split_csv(sub_ids, param_hint="--sub-ids")
     resolved_bids_filters = split_csv(bids_filters, param_hint="--bids-filters")
 
+    layout = BIDSLayout(bids_root)
+
     feature = PhonemicFeature(
-        input_dir=input_dir,
-        output_dir=output_dir,
+        layout=layout,
         use_articulatory=not no_articulatory,
         bids_filters=resolved_bids_filters,
     )
 
-    resolved_sub_ids = resolved_sub_ids or list(
-        {
-            BIDSPath(f).entities["sub"]
-            for f in input_dir.iterdir()
-            if f.is_file() and "sub" in BIDSPath(f).entities
-        }
-    )
+    # TODO: warn when no subjects found (pending logging setup)
+    resolved_sub_ids = resolved_sub_ids or layout.list.subjects(area="stimuli")
 
     for sub_id in resolved_sub_ids:
         feature.generate(sub_id)

--- a/src/hypline/cli/transcribe.py
+++ b/src/hypline/cli/transcribe.py
@@ -4,33 +4,26 @@ from typing import Annotated
 import typer
 
 from hypline.enums import Device
+from hypline.layout import BIDSLayout
 from hypline.transcriber import Transcriber, WhisperConfig, WhisperModel
 
 from ._utils import split_csv
 
 
 def transcribe(
-    input_dir: Annotated[
+    bids_root: Annotated[
         Path,
         typer.Argument(
-            help="Directory containing audio files",
+            help="BIDS dataset root (contains stimuli/, features/, derivatives/)",
             show_default=False,
         ),
     ],
-    output_dir: Annotated[
-        Path,
-        typer.Argument(
-            help="Directory to store word-level transcripts (CSV files)",
-            show_default=False,
-        ),
-    ],
-    file_ext: Annotated[
+    audio_ext: Annotated[
         str,
-        typer.Argument(
-            help="Extension of the audio files (e.g., .wav)",
-            show_default=False,
+        typer.Option(
+            help="Extension of the audio files",
         ),
-    ],
+    ] = ".wav",
     model: Annotated[
         WhisperModel,
         typer.Option(
@@ -56,9 +49,7 @@ def transcribe(
     sub_ids: Annotated[
         str | None,
         typer.Option(
-            help="""
-            Comma-separated subject IDs to process (e.g., 01,02); omit to process all
-            """,
+            help="Comma-separated subject IDs to process (e.g., 01,02); omit for all",
             show_default=False,
         ),
     ] = None,
@@ -73,10 +64,10 @@ def transcribe(
     """
     Transcribe audio files using a Whisper ASR model.
     """
-    from hypline.bids import BIDSPath
-
     resolved_sub_ids = split_csv(sub_ids, param_hint="--sub-ids")
     resolved_bids_filters = split_csv(bids_filters, param_hint="--bids-filters")
+
+    layout = BIDSLayout(bids_root)
 
     config = WhisperConfig(
         model=model,
@@ -86,19 +77,13 @@ def transcribe(
 
     transcriber = Transcriber(
         config,
-        input_dir=input_dir,
-        output_dir=output_dir,
-        audio_ext=file_ext,
+        layout=layout,
+        audio_ext=audio_ext,
         bids_filters=resolved_bids_filters,
     )
 
-    resolved_sub_ids = resolved_sub_ids or list(
-        {
-            BIDSPath(f).entities["sub"]
-            for f in input_dir.iterdir()
-            if f.is_file() and "sub" in BIDSPath(f).entities
-        }
-    )
+    # TODO: warn when no subjects found (pending logging setup)
+    resolved_sub_ids = resolved_sub_ids or layout.list.subjects(area="stimuli")
 
     for sub_id in resolved_sub_ids:
         transcriber.transcribe(sub_id)

--- a/src/hypline/cli/transcribe.py
+++ b/src/hypline/cli/transcribe.py
@@ -54,6 +54,7 @@ def transcribe(
     bids_filters: Annotated[
         str | None,
         typer.Option(
+            "--data-filters",
             help="Comma-separated BIDS entity filters (e.g., run-2,run-4,cond-G)",
             show_default=False,
         ),
@@ -66,7 +67,7 @@ def transcribe(
     from hypline.transcriber import Transcriber, WhisperConfig
 
     resolved_sub_ids = split_csv(sub_ids, param_hint="--sub-ids")
-    resolved_bids_filters = split_csv(bids_filters, param_hint="--bids-filters")
+    resolved_bids_filters = split_csv(bids_filters, param_hint="--data-filters")
 
     layout = BIDSLayout(bids_root)
 

--- a/src/hypline/cli/transcribe.py
+++ b/src/hypline/cli/transcribe.py
@@ -3,9 +3,7 @@ from typing import Annotated
 
 import typer
 
-from hypline.enums import Device
-from hypline.layout import BIDSLayout
-from hypline.transcriber import Transcriber, WhisperConfig, WhisperModel
+from hypline.enums import Device, WhisperModel
 
 from ._utils import split_csv
 
@@ -64,6 +62,9 @@ def transcribe(
     """
     Transcribe audio files using a Whisper ASR model.
     """
+    from hypline.layout import BIDSLayout
+    from hypline.transcriber import Transcriber, WhisperConfig
+
     resolved_sub_ids = split_csv(sub_ids, param_hint="--sub-ids")
     resolved_bids_filters = split_csv(bids_filters, param_hint="--bids-filters")
 

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -1,4 +1,3 @@
-import os
 import reprlib
 from dataclasses import dataclass
 from pathlib import Path
@@ -7,7 +6,6 @@ from typing import Iterator, NamedTuple
 import numpy as np
 from pydantic import BaseModel
 
-from hypline._utils import find_files, validate_dirs
 from hypline.bids import (
     BIDSPath,
     normalize_bids_filters,
@@ -26,6 +24,7 @@ from hypline.features._utils import (
     read_feature_metadata,
     resample_feature,
 )
+from hypline.layout import BIDSLayout
 
 
 class BoldKey(NamedTuple):
@@ -158,9 +157,7 @@ class Encoding:
         self,
         config: EncodingConfig,
         *,
-        features_dir: str | os.PathLike[str],
-        bold_dir: str | os.PathLike[str],
-        output_dir: str | os.PathLike[str],
+        layout: BIDSLayout,
         features: list[str],
         bold_space: str,
         downsample: str | Downsample = "mean",
@@ -171,11 +168,7 @@ class Encoding:
         if config.device is Device.CUDA and not torch.cuda.is_available():
             raise RuntimeError("CUDA is requested but not available")
         self.config = config
-
-        validate_dirs(features_dir, bold_dir, output_dir)
-        self.features_dir = Path(features_dir)
-        self.bold_dir = Path(bold_dir)
-        self.output_dir = Path(output_dir)
+        self._layout = layout
 
         if not features:
             raise ValueError("features must be a non-empty list")
@@ -219,20 +212,14 @@ class Encoding:
         """
         feature_paths: dict[FeatureKey, Path] = {}
         for feature_name in self.features:
-            feature_files = find_files(
-                self.features_dir,
-                ends_with=".parquet",
-                recursive=True,
-                bids_filters=[f"sub-{sub_id}", f"feat-{feature_name}"],
-            )
+            feature_files = self._layout.find.features(sub=sub_id, kind=feature_name)
             if not feature_files:
                 raise FileNotFoundError(
                     f"No matching feature files found for sub={sub_id}, "
-                    f"feature={feature_name} in {self.features_dir}"
+                    f"feature={feature_name}"
                 )
 
-            for feature_file in feature_files:
-                bids = BIDSPath(feature_file)
+            for bids in feature_files:
                 cell_key = CellKey(
                     **{
                         key: val
@@ -245,9 +232,9 @@ class Encoding:
                     loc = _format_loc(sub=sub_id, **dict(cell_key.items()))
                     raise ValueError(
                         f"Multiple feature files for feature={feature_name}, {loc}:\n"
-                        f"  {feature_paths[feature_key]}\n  {feature_file}"
+                        f"  {feature_paths[feature_key]}\n  {bids.path}"
                     )
-                feature_paths[feature_key] = feature_file
+                feature_paths[feature_key] = bids.path
 
         # Validate: all files share the same entity key set
         schema: frozenset[str] | None = None
@@ -315,21 +302,23 @@ class Encoding:
         unsegmented).
         """
         bold_ext = BOLD_EXTENSIONS[type(self.bold_space)]
-        bold_files = find_files(
-            self.bold_dir,
-            ends_with=f"_bold{bold_ext}",
-            recursive=True,
-            bids_filters=[f"sub-{sub_id}", f"space-{self.bold_space}"],
+        bold_files = self._layout.find.fmriprep(
+            sub=sub_id,
+            suffix="bold",
+            ext=bold_ext,
+            bids_filters=[
+                f"space-{self.bold_space}",
+                "desc-clean",  # hardcoded until parameterization is needed
+            ],
         )
         if not bold_files:
             raise FileNotFoundError(
-                f"No BOLD files found for sub={sub_id}, space={self.bold_space} "
-                f"in {self.bold_dir}"
+                f"No BOLD files found for sub={sub_id}, space={self.bold_space}, "
+                f"desc=clean"
             )
 
         bold_metas: dict[BoldKey, BoldMeta] = {}
-        for bold_file in bold_files:
-            bids = BIDSPath(bold_file)
+        for bids in bold_files:
             bold_key = BoldKey(
                 ses=bids.entities.get("ses"),
                 run=bids.entities.get("run"),
@@ -338,10 +327,10 @@ class Encoding:
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
                 raise ValueError(
                     f"Duplicate BOLD file at {loc}:\n"
-                    f"  {bold_metas[bold_key].bids.path}\n  {bold_file}"
+                    f"  {bold_metas[bold_key].bids.path}\n  {bids.path}"
                 )
             try:
-                bold_metas[bold_key] = load_bold_meta(bold_file)
+                bold_metas[bold_key] = load_bold_meta(bids.path)
             except ValueError as e:
                 loc = _format_loc(sub=sub_id, ses=bold_key.ses, run=bold_key.run)
                 raise ValueError(f"Failed to load BOLD at {loc}: {e}") from e

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -57,7 +57,7 @@ class CellKey:
             "den",
             "echo",
             "space",
-            "feature",
+            "feat",
         )
     )
     __slots__ = ("_entities",)
@@ -188,7 +188,7 @@ class Encoding:
         self.downsample = Downsample(downsample)
 
         self.bids_filters = normalize_bids_filters(
-            bids_filters, reserved={"sub", "space", "feature"}
+            bids_filters, reserved={"sub", "space", "feat"}
         )
 
     def train(self, sub_id: str):
@@ -223,7 +223,7 @@ class Encoding:
                 self.features_dir,
                 ends_with=".parquet",
                 recursive=True,
-                bids_filters=[f"sub-{sub_id}", f"feature-{feature_name}"],
+                bids_filters=[f"sub-{sub_id}", f"feat-{feature_name}"],
             )
             if not feature_files:
                 raise FileNotFoundError(

--- a/src/hypline/enums.py
+++ b/src/hypline/enums.py
@@ -6,6 +6,15 @@ class Device(StrEnum):
     CUDA = "cuda"
 
 
+class WhisperModel(StrEnum):
+    TINY = "tiny"
+    BASE = "base"
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE_V2 = "large-v2"
+    LARGE_V3 = "large-v3"
+
+
 class SurfaceSpace(StrEnum):
     FS_AVERAGE_5 = "fsaverage5"
     FS_AVERAGE_6 = "fsaverage6"

--- a/src/hypline/features/_utils.py
+++ b/src/hypline/features/_utils.py
@@ -93,8 +93,8 @@ def resample_feature(
 
 def _validate_feature_path(path: str | os.PathLike[str]) -> BIDSPath:
     bids = BIDSPath(path)
-    if "feature" not in bids.entities:
-        raise ValueError("BIDS path must contain a 'feature' entity")
+    if "feat" not in bids.entities:
+        raise ValueError("BIDS path must contain a 'feat' entity")
     if bids.extension != ".parquet":
         raise ValueError(
             f"Feature path must have .parquet extension, got {bids.extension!r}"
@@ -146,7 +146,7 @@ def save_feature(
         `feature` must be an Array or List type.
     path
         BIDS-compliant path to a `.parquet` feature file. Must contain
-        a `feature` entity (e.g., `feature-mfcc`).
+        a `feat` entity (e.g., `feat-mfcc`).
     metadata
         Optional metadata merged into the Parquet footer. Must not
         contain `feature_name` or `hypline_version`.
@@ -155,7 +155,7 @@ def save_feature(
     ------
     ValueError
         If required columns are missing, `feature` dtype is unsupported,
-        the path lacks a `feature` entity, or `metadata` contains a
+        the path lacks a `feat` entity, or `metadata` contains a
         reserved key (`feature_name`, `hypline_version`).
     """
     bids = _validate_feature_path(path)
@@ -166,7 +166,7 @@ def save_feature(
             f"metadata must not contain reserved keys: {reserved & metadata.keys()}"
         )
     auto_metadata = {
-        "feature_name": bids.entities["feature"],
+        "feature_name": bids.entities["feat"],
         "hypline_version": __version__,
     }
     metadata = {**(metadata or {}), **auto_metadata}
@@ -190,10 +190,10 @@ def _parse_feature_metadata(raw_metadata: dict, bids: BIDSPath) -> dict[str, Any
         )
 
     metadata = json.loads(blob)
-    if metadata.get("feature_name") != bids.entities["feature"]:
+    if metadata.get("feature_name") != bids.entities["feat"]:
         raise ValueError(
             f"feature_name metadata {metadata.get('feature_name')!r} "
-            f"does not match path entity {bids.entities['feature']!r}"
+            f"does not match path entity {bids.entities['feat']!r}"
         )
 
     return metadata
@@ -206,7 +206,7 @@ def read_feature(path: str | os.PathLike[str]) -> pl.DataFrame:
     ----------
     path
         BIDS-compliant path to a `.parquet` feature file. Must contain
-        a `feature` entity (e.g., `feature-mfcc`).
+        a `feat` entity (e.g., `feat-mfcc`).
 
     Returns
     -------
@@ -216,7 +216,7 @@ def read_feature(path: str | os.PathLike[str]) -> pl.DataFrame:
     Raises
     ------
     ValueError
-        If the path lacks a `feature` entity, a `start_time` or `feature`
+        If the path lacks a `feat` entity, a `start_time` or `feature`
         column is missing, the `feature` column is not `Array(Float64)`, or
         `feature_name` metadata does not match the path entity.
     """
@@ -242,7 +242,7 @@ def read_feature_metadata(path: str | os.PathLike[str]) -> dict[str, Any]:
     Raises
     ------
     ValueError
-        If the path lacks a `feature` entity, the file has no hypline
+        If the path lacks a `feat` entity, the file has no hypline
         metadata, or `feature_name` does not match the path entity.
     """
     bids = _validate_feature_path(path)

--- a/src/hypline/features/phonemic.py
+++ b/src/hypline/features/phonemic.py
@@ -131,7 +131,7 @@ class PhonemicFeature:
                 )
             )
 
-            bids_path = BIDSPath(transcript).with_entity("feature", "phonemic")
+            bids_path = BIDSPath(transcript).with_entity("feat", "phonemic")
             out_path = self._output_dir / (bids_path.path.stem + ".parquet")
             metadata = {
                 "use_articulatory": self._use_articulatory,

--- a/src/hypline/features/phonemic.py
+++ b/src/hypline/features/phonemic.py
@@ -1,13 +1,10 @@
-import os
 from importlib.resources import files
-from pathlib import Path
 
 import numpy as np
 import polars as pl
 
-from hypline._utils import find_files, validate_dirs
-from hypline.bids import BIDSPath, normalize_bids_filters
 from hypline.features._utils import save_feature
+from hypline.layout import BIDSLayout
 
 ARPABET_PHONEMES = [
     "B",
@@ -63,20 +60,15 @@ class PhonemicFeature:
     def __init__(
         self,
         *,
-        input_dir: str | os.PathLike[str],
-        output_dir: str | os.PathLike[str],
+        layout: BIDSLayout,
         use_articulatory: bool = True,
         bids_filters: list[str] | None = None,
     ):
         self._load()
 
-        validate_dirs(input_dir, output_dir)
-        self._input_dir = Path(input_dir)
-        self._output_dir = Path(output_dir)
-
+        self._layout = layout
         self._use_articulatory = use_articulatory
-
-        self._bids_filters = normalize_bids_filters(bids_filters, reserved={"sub"})
+        self._bids_filters = bids_filters
 
     @classmethod
     def _load(cls):
@@ -113,14 +105,15 @@ class PhonemicFeature:
             else self._get_word_phoneme_vector
         )
 
-        transcripts = find_files(
-            self._input_dir,
-            ends_with=".csv",
-            bids_filters=[f"sub-{sub_id}", *self._bids_filters],
+        transcripts = self._layout.find.stimuli(
+            sub=sub_id,
+            kind="transcript",
+            ext=".csv",
+            bids_filters=self._bids_filters,
         )
 
         for transcript in transcripts:
-            df = pl.read_csv(transcript)
+            df = pl.read_csv(transcript.path)
             words = df.get_column("word").cast(pl.Utf8).str.strip_chars(PUNCTUATION)
             features = np.vstack([feature_fn(w) for w in words.to_list()])
             df = df.with_columns(
@@ -131,8 +124,9 @@ class PhonemicFeature:
                 )
             )
 
-            bids_path = BIDSPath(transcript).with_entity("feat", "phonemic")
-            out_path = self._output_dir / (bids_path.path.stem + ".parquet")
+            out = self._layout.build.feature(source=transcript, kind="phonemic")
+            out.path.parent.mkdir(parents=True, exist_ok=True)
+
             metadata = {
                 "use_articulatory": self._use_articulatory,
                 "dim_labels": (
@@ -141,7 +135,8 @@ class PhonemicFeature:
                     else ARPABET_PHONEMES
                 ),
             }
-            save_feature(df, out_path, metadata=metadata)
+
+            save_feature(df, out.path, metadata=metadata)
 
     def _get_word_phoneme_vector(self, word: str) -> np.ndarray:
         vec = np.zeros(len(ARPABET_PHONEMES))

--- a/src/hypline/layout.py
+++ b/src/hypline/layout.py
@@ -183,7 +183,7 @@ class _List:
     def __init__(self, root: Path):
         self._root = root
 
-    def subjects(self, area: _Area) -> list[str]:
+    def subjects(self, *, area: _Area) -> list[str]:
         """Return sorted unique subject IDs present in the given area."""
         area_dir = _area_root(self._root, area)
         if not area_dir.exists():

--- a/src/hypline/layout.py
+++ b/src/hypline/layout.py
@@ -1,0 +1,226 @@
+import os
+from pathlib import Path
+from typing import Literal
+
+from hypline.bids import (
+    BIDSPath,
+    find_bids_files,
+    normalize_bids_filters,
+    validate_extension,
+)
+
+_Area = Literal["stimuli", "features", "fmriprep"]
+
+
+def _area_root(root: Path, area: _Area) -> Path:
+    if area == "fmriprep":
+        return root / "derivatives" / "fmriprep"
+    return root / area
+
+
+def _kind_dirs(sub_dir: Path, kind: str, ses_values: list[str] | None) -> list[Path]:
+    """Return existing <kind>/ dirs under sub_dir for the given sessions.
+
+    When `ses_values` is None, returns both `ses-*/<kind>/` dirs and the
+    sub-level `<kind>/` dir (BIDS allows session to be omitted).
+    """
+    if ses_values is None:
+        ses_dirs = sorted(p for p in sub_dir.glob("ses-*") if p.is_dir())
+        candidates = [d / kind for d in ses_dirs] + [sub_dir / kind]
+    else:
+        candidates = [sub_dir / f"ses-{ses}" / kind for ses in ses_values]
+    return [d for d in candidates if d.is_dir()]
+
+
+class _Find:
+    def __init__(self, root: Path):
+        self._root = root
+
+    def stimuli(
+        self,
+        *,
+        sub: str,
+        kind: str,
+        ext: str,
+        bids_filters: list[str] | None = None,
+    ) -> list["BIDSPath"]:
+        """Find stimulus files.
+
+        `kind` maps to the stim-<kind> entity and the per-session subdirectory name.
+        """
+        filters = normalize_bids_filters(bids_filters, reserved={"sub", "stim"})
+        ses_values = [f[4:] for f in filters if f.startswith("ses-")] or None
+        filters = [f for f in filters if not f.startswith("ses-")]
+        filters.extend([f"sub-{sub}", f"stim-{kind}"])
+
+        sub_dir = _area_root(self._root, "stimuli") / f"sub-{sub}"
+        if not sub_dir.exists():
+            return []
+
+        results: list[BIDSPath] = []
+        for dir in _kind_dirs(sub_dir, kind, ses_values):
+            results.extend(find_bids_files(dir, ext, bids_filters=filters))
+        return sorted(results)
+
+    def features(
+        self,
+        *,
+        sub: str,
+        kind: str,
+        bids_filters: list[str] | None = None,
+    ) -> list["BIDSPath"]:
+        """Find feature files.
+
+        `kind` maps to the feature-<kind> entity and the per-session subdirectory
+        name. Extension is `.parquet`.
+        """
+        filters = normalize_bids_filters(bids_filters, reserved={"sub", "feature"})
+        ses_values = [f[4:] for f in filters if f.startswith("ses-")] or None
+        filters = [f for f in filters if not f.startswith("ses-")]
+        filters.extend([f"sub-{sub}", f"feature-{kind}"])
+
+        sub_dir = _area_root(self._root, "features") / f"sub-{sub}"
+        if not sub_dir.exists():
+            return []
+
+        results: list[BIDSPath] = []
+        for dir in _kind_dirs(sub_dir, kind, ses_values):
+            results.extend(find_bids_files(dir, ".parquet", bids_filters=filters))
+        return sorted(results)
+
+    def fmriprep(
+        self,
+        *,
+        sub: str,
+        suffix: str,
+        ext: str,
+        bids_filters: list[str] | None = None,
+    ) -> list["BIDSPath"]:
+        filters = normalize_bids_filters(bids_filters, reserved={"sub"})
+        ses_values = [f[4:] for f in filters if f.startswith("ses-")] or None
+        filters = [f for f in filters if not f.startswith("ses-")]
+        filters.extend([f"sub-{sub}"])
+
+        sub_dir = _area_root(self._root, "fmriprep") / f"sub-{sub}"
+        if not sub_dir.exists():
+            return []
+
+        results: list[BIDSPath] = []
+        for dir in _kind_dirs(sub_dir, "func", ses_values):
+            results.extend(
+                find_bids_files(dir, ext, suffix=suffix, bids_filters=filters)
+            )
+        return sorted(results)
+
+
+class _Build:
+    def __init__(self, root: Path):
+        self._root = root
+
+    def stimulus(
+        self,
+        *,
+        source: BIDSPath,
+        kind: str,
+        ext: str,
+        **entity_overrides: str,
+    ) -> BIDSPath:
+        """Derive a stimulus output path from `source`.
+
+        Sets stim-<kind>, applies `entity_overrides`, and places the result
+        under stimuli/sub-XX/[ses-YY/]<kind>/.
+        """
+        validate_extension(ext)
+        bp = source.with_entity("stim", kind)
+        for key, value in entity_overrides.items():
+            bp = bp.with_entity(key, value)
+
+        entities = bp.entities
+        sub = entities.get("sub")
+        ses = entities.get("ses")
+        if sub is None:
+            raise ValueError(f"source has no 'sub' entity: {source!r}")
+
+        sub_dir = _area_root(self._root, "stimuli") / f"sub-{sub}"
+        out_dir = sub_dir / f"ses-{ses}" / kind if ses is not None else sub_dir / kind
+
+        stem = "_".join(f"{k}-{v}" for k, v in entities.items())
+        name = f"{stem}{ext}"
+
+        return BIDSPath(out_dir / name)
+
+    def feature(
+        self,
+        *,
+        source: BIDSPath,
+        kind: str,
+        **entity_overrides: str,
+    ) -> BIDSPath:
+        """Derive a feature output path from `source`.
+
+        Sets feature-<kind>, applies `entity_overrides`, and places the result
+        under features/sub-XX/[ses-YY/]<kind>/ with `.parquet` extension.
+        """
+        bp = source.with_entity("feature", kind)
+        for key, value in entity_overrides.items():
+            bp = bp.with_entity(key, value)
+
+        entities = bp.entities
+        sub = entities.get("sub")
+        ses = entities.get("ses")
+        if sub is None:
+            raise ValueError(f"source has no 'sub' entity: {source!r}")
+
+        sub_dir = _area_root(self._root, "features") / f"sub-{sub}"
+        out_dir = sub_dir / f"ses-{ses}" / kind if ses is not None else sub_dir / kind
+
+        stem = "_".join(f"{k}-{v}" for k, v in entities.items())
+        name = f"{stem}.parquet"
+        return BIDSPath(out_dir / name)
+
+
+class _List:
+    def __init__(self, root: Path):
+        self._root = root
+
+    def subjects(self, area: _Area) -> list[str]:
+        """Return sorted unique subject IDs present in the given area."""
+        area_dir = _area_root(self._root, area)
+        if not area_dir.exists():
+            return []
+
+        ids: set[str] = set()
+        for p in area_dir.iterdir():
+            if p.is_dir() and p.name.startswith("sub-"):
+                ids.add(p.name[4:])
+
+        return sorted(ids)
+
+    def sessions(self, *, sub: str, area: _Area) -> list[str]:
+        """Return sorted unique session IDs for a subject in the given area."""
+        sub_dir = _area_root(self._root, area) / f"sub-{sub}"
+        if not sub_dir.exists():
+            return []
+
+        ids: set[str] = set()
+        for p in sub_dir.iterdir():
+            if p.is_dir() and p.name.startswith("ses-"):
+                ids.add(p.name[4:])
+
+        return sorted(ids)
+
+
+class BIDSLayout:
+    """Single authority on path discovery and derivation for a hypline BIDS tree.
+
+    Validates root_dir exists on construction; does not validate per-area subdirs
+    (features/ may be absent before featuregen runs).
+    """
+
+    def __init__(self, root_dir: str | os.PathLike[str]):
+        self._root = Path(root_dir)
+        if not self._root.exists():
+            raise FileNotFoundError(f"root_dir does not exist: {self._root}")
+        self.find = _Find(self._root)
+        self.build = _Build(self._root)
+        self.list = _List(self._root)

--- a/src/hypline/layout.py
+++ b/src/hypline/layout.py
@@ -117,6 +117,34 @@ class _Build:
     def __init__(self, root: Path):
         self._root = root
 
+    def _derive_path(
+        self,
+        *,
+        area: _Area,
+        entity_key: str,
+        source: BIDSPath,
+        kind: str,
+        ext: str,
+        entity_overrides: dict[str, str],
+    ) -> BIDSPath:
+        validate_extension(ext)
+        bp = source.with_entity(entity_key, kind)
+        for key, value in entity_overrides.items():
+            bp = bp.with_entity(key, value)
+
+        entities = bp.entities
+        sub = entities.get("sub")
+        ses = entities.get("ses")
+        if sub is None:
+            raise ValueError(f"source has no 'sub' entity: {source!r}")
+
+        sub_dir = _area_root(self._root, area) / f"sub-{sub}"
+        out_dir = sub_dir / f"ses-{ses}" / kind if ses is not None else sub_dir / kind
+
+        stem = "_".join(f"{k}-{v}" for k, v in entities.items())
+
+        return BIDSPath(out_dir / f"{stem}{ext}")
+
     def stimulus(
         self,
         *,
@@ -130,24 +158,14 @@ class _Build:
         Sets stim-<kind>, applies `entity_overrides`, and places the result
         under stimuli/sub-XX/[ses-YY/]<kind>/.
         """
-        validate_extension(ext)
-        bp = source.with_entity("stim", kind)
-        for key, value in entity_overrides.items():
-            bp = bp.with_entity(key, value)
-
-        entities = bp.entities
-        sub = entities.get("sub")
-        ses = entities.get("ses")
-        if sub is None:
-            raise ValueError(f"source has no 'sub' entity: {source!r}")
-
-        sub_dir = _area_root(self._root, "stimuli") / f"sub-{sub}"
-        out_dir = sub_dir / f"ses-{ses}" / kind if ses is not None else sub_dir / kind
-
-        stem = "_".join(f"{k}-{v}" for k, v in entities.items())
-        name = f"{stem}{ext}"
-
-        return BIDSPath(out_dir / name)
+        return self._derive_path(
+            area="stimuli",
+            entity_key="stim",
+            source=source,
+            kind=kind,
+            ext=ext,
+            entity_overrides=entity_overrides,
+        )
 
     def feature(
         self,
@@ -161,22 +179,14 @@ class _Build:
         Sets feat-<kind>, applies `entity_overrides`, and places the result
         under features/sub-XX/[ses-YY/]<kind>/ with `.parquet` extension.
         """
-        bp = source.with_entity("feat", kind)
-        for key, value in entity_overrides.items():
-            bp = bp.with_entity(key, value)
-
-        entities = bp.entities
-        sub = entities.get("sub")
-        ses = entities.get("ses")
-        if sub is None:
-            raise ValueError(f"source has no 'sub' entity: {source!r}")
-
-        sub_dir = _area_root(self._root, "features") / f"sub-{sub}"
-        out_dir = sub_dir / f"ses-{ses}" / kind if ses is not None else sub_dir / kind
-
-        stem = "_".join(f"{k}-{v}" for k, v in entities.items())
-        name = f"{stem}.parquet"
-        return BIDSPath(out_dir / name)
+        return self._derive_path(
+            area="features",
+            entity_key="feat",
+            source=source,
+            kind=kind,
+            ext=".parquet",
+            entity_overrides=entity_overrides,
+        )
 
 
 class _List:

--- a/src/hypline/layout.py
+++ b/src/hypline/layout.py
@@ -223,14 +223,14 @@ class _List:
 class BIDSLayout:
     """Single authority on path discovery and derivation for a hypline BIDS tree.
 
-    Validates root_dir exists on construction; does not validate per-area subdirs
+    Validates bids_root exists on construction; does not validate per-area subdirs
     (features/ may be absent before featuregen runs).
     """
 
-    def __init__(self, root_dir: str | os.PathLike[str]):
-        self._root = Path(root_dir)
+    def __init__(self, bids_root: str | os.PathLike[str]):
+        self._root = Path(bids_root)
         if not self._root.exists():
-            raise FileNotFoundError(f"root_dir does not exist: {self._root}")
+            raise FileNotFoundError(f"bids_root does not exist: {self._root}")
         self.find = _Find(self._root)
         self.build = _Build(self._root)
         self.list = _List(self._root)

--- a/src/hypline/layout.py
+++ b/src/hypline/layout.py
@@ -71,13 +71,13 @@ class _Find:
     ) -> list["BIDSPath"]:
         """Find feature files.
 
-        `kind` maps to the feature-<kind> entity and the per-session subdirectory
+        `kind` maps to the feat-<kind> entity and the per-session subdirectory
         name. Extension is `.parquet`.
         """
-        filters = normalize_bids_filters(bids_filters, reserved={"sub", "feature"})
+        filters = normalize_bids_filters(bids_filters, reserved={"sub", "feat"})
         ses_values = [f[4:] for f in filters if f.startswith("ses-")] or None
         filters = [f for f in filters if not f.startswith("ses-")]
-        filters.extend([f"sub-{sub}", f"feature-{kind}"])
+        filters.extend([f"sub-{sub}", f"feat-{kind}"])
 
         sub_dir = _area_root(self._root, "features") / f"sub-{sub}"
         if not sub_dir.exists():
@@ -158,10 +158,10 @@ class _Build:
     ) -> BIDSPath:
         """Derive a feature output path from `source`.
 
-        Sets feature-<kind>, applies `entity_overrides`, and places the result
+        Sets feat-<kind>, applies `entity_overrides`, and places the result
         under features/sub-XX/[ses-YY/]<kind>/ with `.parquet` extension.
         """
-        bp = source.with_entity("feature", kind)
+        bp = source.with_entity("feat", kind)
         for key, value in entity_overrides.items():
             bp = bp.with_entity(key, value)
 

--- a/src/hypline/transcriber.py
+++ b/src/hypline/transcriber.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import tempfile
 from enum import StrEnum
@@ -6,9 +5,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, field_validator
 
-from hypline._utils import find_files, validate_dirs
-from hypline.bids import normalize_bids_filters
 from hypline.enums import Device
+from hypline.layout import BIDSLayout
 
 
 class WhisperModel(StrEnum):
@@ -43,8 +41,7 @@ class Transcriber:
         self,
         config: WhisperConfig,
         *,
-        input_dir: str | os.PathLike[str],
-        output_dir: str | os.PathLike[str],
+        layout: BIDSLayout,
         audio_ext: str,
         bids_filters: list[str] | None = None,
     ):
@@ -64,14 +61,9 @@ class Transcriber:
         assert config.model_dir is not None  # For type inference
 
         self.config = config
-
-        validate_dirs(input_dir, output_dir)
-        self._input_dir = Path(input_dir)
-        self._output_dir = Path(output_dir)
-
+        self._layout = layout
         self._audio_ext = audio_ext
-
-        self._bids_filters = normalize_bids_filters(bids_filters, reserved={"sub"})
+        self._bids_filters = bids_filters
 
         self._model = whisperx.load_model(
             whisper_arch=config.model,
@@ -92,10 +84,11 @@ class Transcriber:
         import polars as pl
         import whisperx
 
-        audio_files = find_files(
-            self._input_dir,
-            ends_with=self._audio_ext,
-            bids_filters=[f"sub-{sub_id}", *self._bids_filters],
+        audio_files = self._layout.find.stimuli(
+            sub=sub_id,
+            kind="audio",
+            ext=self._audio_ext,
+            bids_filters=self._bids_filters,
         )
 
         batch_size = self.config.batch_size
@@ -103,7 +96,7 @@ class Transcriber:
             batch_size = 16 if self.config.device is Device.CUDA else 1
 
         for audio_file in audio_files:
-            audio = whisperx.load_audio(str(audio_file))
+            audio = whisperx.load_audio(str(audio_file.path))
 
             result = self._model.transcribe(audio, batch_size=batch_size)
             result = whisperx.align(
@@ -122,5 +115,10 @@ class Transcriber:
                     "score": "confidence_score",
                 }
             )
-            output_file = self._output_dir / f"{audio_file.stem}.csv"
-            df.write_csv(output_file)
+            out = self._layout.build.stimulus(
+                source=audio_file,
+                kind="transcript",
+                ext=".csv",
+            )
+            out.path.parent.mkdir(parents=True, exist_ok=True)
+            df.write_csv(out.path)

--- a/src/hypline/transcriber.py
+++ b/src/hypline/transcriber.py
@@ -1,21 +1,11 @@
 import shutil
 import tempfile
-from enum import StrEnum
 from pathlib import Path
 
 from pydantic import BaseModel, field_validator
 
-from hypline.enums import Device
+from hypline.enums import Device, WhisperModel
 from hypline.layout import BIDSLayout
-
-
-class WhisperModel(StrEnum):
-    TINY = "tiny"
-    BASE = "base"
-    SMALL = "small"
-    MEDIUM = "medium"
-    LARGE_V2 = "large-v2"
-    LARGE_V3 = "large-v3"
 
 
 class WhisperConfig(BaseModel):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -92,7 +92,7 @@ class BIDSTree:
 
         entities = self._identity_entities(sub, ses, task, run)
         entities.update(extra_entities)
-        entities["feature"] = feature
+        entities["feat"] = feature
         directory = self.features_dir if subdir is None else self.features_dir / subdir
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / f"{self._stem(entities)}.parquet"
@@ -327,7 +327,7 @@ class HyplineBIDSTree:
         **extra_entities: str,
     ) -> Path:
         entities = self._entities(sub, ses, task, run, **extra_entities)
-        entities["feature"] = kind
+        entities["feat"] = kind
         stem = self._stem(entities)
         sub_dir = self.root / "features" / f"sub-{sub}"
         ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -257,3 +257,123 @@ class BIDSTree:
 @pytest.fixture()
 def tree(tmp_path: Path) -> BIDSTree:
     return BIDSTree(tmp_path)
+
+
+# TODO: consolidate HyplineBIDSTree with BIDSTree
+class HyplineBIDSTree:
+    """Minimal on-disk fixture for BIDSLayout tests.
+
+    Matches the hypline BIDS tree layout; `ses` is optional in all helpers:
+        stimuli/sub-XX/[ses-YY/]<kind>/
+        features/sub-XX/[ses-YY/]<kind>/
+        derivatives/fmriprep/sub-XX/[ses-YY/]func/
+    """
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    def _stem(self, entities: dict[str, str]) -> str:
+        return "_".join(f"{k}-{v}" for k, v in entities.items())
+
+    def _write(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        return path
+
+    def _entities(
+        self,
+        sub: str,
+        ses: str | None,
+        task: str | None,
+        run: str | None,
+        **extra: str,
+    ) -> dict[str, str]:
+        entities: dict[str, str] = {"sub": sub}
+        if ses is not None:
+            entities["ses"] = ses
+        if task is not None:
+            entities["task"] = task
+        if run is not None:
+            entities["run"] = run
+        entities.update(extra)
+        return entities
+
+    def add_stimulus(
+        self,
+        *,
+        kind: str,
+        ext: str,
+        sub: str,
+        ses: str | None = None,
+        task: str | None = None,
+        run: str | None = None,
+        **extra_entities: str,
+    ) -> Path:
+        entities = self._entities(sub, ses, task, run, **extra_entities)
+        entities["stim"] = kind
+        stem = self._stem(entities)
+        sub_dir = self.root / "stimuli" / f"sub-{sub}"
+        ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir
+        return self._write(ses_dir / kind / f"{stem}{ext}")
+
+    def add_feature(
+        self,
+        *,
+        kind: str,
+        sub: str,
+        ses: str | None = None,
+        task: str | None = None,
+        run: str | None = None,
+        **extra_entities: str,
+    ) -> Path:
+        entities = self._entities(sub, ses, task, run, **extra_entities)
+        entities["feature"] = kind
+        stem = self._stem(entities)
+        sub_dir = self.root / "features" / f"sub-{sub}"
+        ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir
+        return self._write(ses_dir / kind / f"{stem}.parquet")
+
+    def add_fmriprep(
+        self,
+        *,
+        suffix: str,
+        ext: str,
+        sub: str,
+        ses: str | None = None,
+        task: str | None = None,
+        run: str | None = None,
+        **extra_entities: str,
+    ) -> Path:
+        entities = self._entities(sub, ses, task, run, **extra_entities)
+        stem = self._stem(entities)
+        sub_dir = self.root / "derivatives" / "fmriprep" / f"sub-{sub}"
+        ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir
+        return self._write(ses_dir / "func" / f"{stem}_{suffix}{ext}")
+
+    def add_fmriprep_bold(
+        self,
+        *,
+        space: str,
+        desc: str = "preproc",
+        sub: str,
+        ses: str | None = None,
+        task: str | None = None,
+        run: str | None = None,
+        **extra_entities: str,
+    ) -> Path:
+        return self.add_fmriprep(
+            suffix="bold",
+            ext=".nii.gz",
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
+            space=space,
+            desc=desc,
+            **extra_entities,
+        )
+
+
+@pytest.fixture()
+def layout_tree(tmp_path: Path) -> HyplineBIDSTree:
+    return HyplineBIDSTree(tmp_path)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,56 +1,55 @@
+import json
 from pathlib import Path
 from typing import Any
 
 import polars as pl
 import pytest
 
-SUB = "001"
-TASK = "conv"
-SPACE = "MNI152NLin6Asym"
-
 
 class BIDSTree:
-    """Minimal on-disk fixture for BIDS-derivatives tests.
+    """Minimal on-disk fixture mirroring the hypline BIDS tree.
 
-    Naming follows fMRIPrep BIDS-derivatives convention. Most files are
-    empty placeholders; feature files contain real parquet data. All three
-    dirs are pre-created under a single tmp_path root.
+    Layout (`ses` is optional everywhere):
+        stimuli/sub-XX/[ses-YY/]<kind>/
+        features/sub-XX/[ses-YY/]<kind>/
+        derivatives/fmriprep/sub-XX/[ses-YY/]func/
+
+    All helpers require identity entities (`sub`, optional `ses`, `task`, `run`)
+    specified explicitly so the data shape stays readable at the callsite.
     """
 
     def __init__(self, root: Path):
-        self.features_dir = root / "features"
-        self.bold_dir = root / "bold"
-        self.output_dir = root / "output"
-        for dir in (self.features_dir, self.bold_dir, self.output_dir):
-            dir.mkdir(parents=True)
+        self.root = root
+
+    @property
+    def stimuli_dir(self) -> Path:
+        return self.root / "stimuli"
+
+    @property
+    def features_dir(self) -> Path:
+        return self.root / "features"
+
+    @property
+    def fmriprep_dir(self) -> Path:
+        return self.root / "derivatives" / "fmriprep"
+
+    @property
+    def results_dir(self) -> Path:
+        return self.root / "results"
+
+    def func_dir(self, *, sub: str, ses: str | None = None) -> Path:
+        return self._sub_ses_dir(self.fmriprep_dir, sub, ses) / "func"
 
     def _stem(self, entities: dict[str, str]) -> str:
         return "_".join(f"{k}-{v}" for k, v in entities.items())
 
-    def _write(
-        self,
-        directory: Path,
-        entities: dict[str, str],
-        *,
-        suffix: str | None = None,
-        ext: str,
-        sidecar_json: str | None = None,
-    ) -> Path:
-        directory.mkdir(parents=True, exist_ok=True)
-        stem = self._stem(entities)
-        name = stem if suffix is None else f"{stem}_{suffix}"
-        path = directory / f"{name}{ext}"
-        path.touch()
-        if sidecar_json is not None:
-            (directory / f"{name}.json").write_text(sidecar_json)
-        return path
-
-    def _identity_entities(
+    def _identity(
         self,
         sub: str,
         ses: str | None,
         task: str | None,
         run: str | None,
+        **extra_entities: str,
     ) -> dict[str, str]:
         entities: dict[str, str] = {"sub": sub}
         if ses is not None:
@@ -59,43 +58,55 @@ class BIDSTree:
             entities["task"] = task
         if run is not None:
             entities["run"] = run
+        entities.update(extra_entities)
         return entities
 
-    def _bold_entities(
+    def _sub_ses_dir(self, area_root: Path, sub: str, ses: str | None) -> Path:
+        sub_dir = area_root / f"sub-{sub}"
+        return sub_dir / f"ses-{ses}" if ses is not None else sub_dir
+
+    def _touch(self, path: Path, *, sidecar_json: dict | None = None) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        if sidecar_json is not None:
+            stem = path.name.partition(".")[0]  # handle compound exts like `.nii.gz`
+            (path.parent / f"{stem}.json").write_text(json.dumps(sidecar_json))
+        return path
+
+    def add_stimulus(
         self,
+        *,
         sub: str,
-        ses: str | None,
-        task: str | None,
-        run: str | None,
-        space: str,
-        desc: str,
-    ) -> dict[str, str]:
-        return {
-            **self._identity_entities(sub, ses, task, run),
-            "space": space,
-            "desc": desc,
-        }
+        ses: str | None = None,
+        task: str | None = None,
+        run: str | None = None,
+        kind: str,
+        ext: str,
+        **extra_entities: str,
+    ) -> Path:
+        entities = self._identity(sub, ses, task, run, **extra_entities)
+        entities["stim"] = kind
+        kind_dir = self._sub_ses_dir(self.stimuli_dir, sub, ses) / kind
+        return self._touch(kind_dir / f"{self._stem(entities)}{ext}")
 
     def add_feature(
         self,
-        feature: str,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
-        subdir: str | None = None,
+        kind: str,
         metadata: dict[str, Any] | None = None,
         **extra_entities: str,
     ) -> Path:
         from hypline.features import save_feature
 
-        entities = self._identity_entities(sub, ses, task, run)
-        entities.update(extra_entities)
-        entities["feat"] = feature
-        directory = self.features_dir if subdir is None else self.features_dir / subdir
-        directory.mkdir(parents=True, exist_ok=True)
-        path = directory / f"{self._stem(entities)}.parquet"
+        entities = self._identity(sub, ses, task, run, **extra_entities)
+        entities["feat"] = kind
+        kind_dir = self._sub_ses_dir(self.features_dir, sub, ses) / kind
+        kind_dir.mkdir(parents=True, exist_ok=True)
+        path = kind_dir / f"{self._stem(entities)}.parquet"
         df = pl.DataFrame(
             {"start_time": [0.0], "feature": [[0.0]]},
             schema={"start_time": pl.Float64, "feature": pl.Array(pl.Float64, 1)},
@@ -103,145 +114,182 @@ class BIDSTree:
         save_feature(df, path, metadata=metadata)
         return path
 
+    def _add_fmriprep(
+        self,
+        *,
+        sub: str,
+        ses: str | None,
+        task: str | None,
+        run: str | None,
+        suffix: str,
+        ext: str,
+        sidecar_json: dict | None = None,
+        **extra_entities: str,
+    ) -> Path:
+        entities = self._identity(sub, ses, task, run, **extra_entities)
+        path = self.func_dir(sub=sub, ses=ses) / f"{self._stem(entities)}_{suffix}{ext}"
+        return self._touch(path, sidecar_json=sidecar_json)
+
     def add_bold(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
-        tr: float = 2.0,
-        space: str = SPACE,
+        space: str,
         desc: str = "preproc",
-        subdir: str | None = None,
+        tr: float = 2.0,
+        **extra_entities: str,
     ) -> Path:
-        entities = self._bold_entities(sub, ses, task, run, space, desc)
-        directory = self.bold_dir if subdir is None else self.bold_dir / subdir
-        return self._write(
-            directory,
-            entities,
+        return self._add_fmriprep(
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
             suffix="bold",
             ext=".nii.gz",
-            sidecar_json=f'{{"RepetitionTime": {tr}}}',
+            sidecar_json={"RepetitionTime": tr},
+            space=space,
+            desc=desc,
+            **extra_entities,
         )
 
     def add_events(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
         rows: list[dict[str, str | float]] | None = None,
         events_json: dict | None = None,
     ) -> Path:
-        """Write an events.tsv file, optionally with a colocated events.json sidecar.
+        """Write events.tsv (and optionally events.json) colocated with BOLD."""
+        stem = self._stem(self._identity(sub, ses, task, run))
+        func = self.func_dir(sub=sub, ses=ses)
+        func.mkdir(parents=True, exist_ok=True)
 
-        rows is a list of dicts with trial_type, onset, duration, e.g.:
-            [{"trial_type": "block-1", "onset": 0.0, "duration": 100.0}]
-
-        events_json, if provided, is written to matching events.json sidecar as raw JSON
-        (e.g., {"trial_type": {"Levels": {"block-1": {"metadata": {"cond": "R"}}}}}).
-        """
-        import json
-
-        identity = self._identity_entities(sub, ses, task, run)
-        stem = self._stem(identity)
-
-        tsv_rows = []
-        if rows:
-            for row in rows:
-                tsv_rows.append(
-                    f"{row['trial_type']}\t{row['onset']}\t{row['duration']}"
-                )
-        events_path = self.bold_dir / f"{stem}_events.tsv"
+        tsv_rows = [
+            f"{row['trial_type']}\t{row['onset']}\t{row['duration']}"
+            for row in (rows or [])
+        ]
+        events_path = func / f"{stem}_events.tsv"
         events_path.write_text("trial_type\tonset\tduration\n" + "\n".join(tsv_rows))
 
         if events_json is not None:
-            (self.bold_dir / f"{stem}_events.json").write_text(json.dumps(events_json))
+            (func / f"{stem}_events.json").write_text(json.dumps(events_json))
 
         return events_path
 
     def add_boldref(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
-        space: str = SPACE,
+        space: str,
     ) -> Path:
-        return self._write(
-            self.bold_dir,
-            self._bold_entities(sub, ses, task, run, space, "preproc"),
+        return self._add_fmriprep(
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
             suffix="boldref",
             ext=".nii.gz",
+            space=space,
+            desc="preproc",
         )
 
     def add_brain_mask(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
-        space: str = SPACE,
+        space: str,
     ) -> Path:
-        entities = self._bold_entities(sub, ses, task, run, space, "brain")
-        return self._write(
-            self.bold_dir, entities, suffix="mask", ext=".nii.gz", sidecar_json="{}"
+        return self._add_fmriprep(
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
+            suffix="mask",
+            ext=".nii.gz",
+            sidecar_json={},
+            space=space,
+            desc="brain",
         )
 
     def add_dseg(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
-        space: str = SPACE,
+        space: str,
         desc: str = "aparcaseg",
     ) -> Path:
-        entities = self._bold_entities(sub, ses, task, run, space, desc)
-        return self._write(self.bold_dir, entities, suffix="dseg", ext=".nii.gz")
+        return self._add_fmriprep(
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
+            suffix="dseg",
+            ext=".nii.gz",
+            space=space,
+            desc=desc,
+        )
 
     def add_confounds(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
     ) -> Path:
-        entities = {**self._identity_entities(sub, ses, task, run), "desc": "confounds"}
-        return self._write(
-            self.bold_dir, entities, suffix="timeseries", ext=".tsv", sidecar_json="{}"
+        return self._add_fmriprep(
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
+            suffix="timeseries",
+            ext=".tsv",
+            sidecar_json={},
+            desc="confounds",
         )
 
     def add_xfm(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
     ) -> Path:
-        entities = {
-            **self._identity_entities(sub, ses, task, run),
-            "from": "T1w",
-            "to": "scanner",
-            "mode": "image",
-        }
-        return self._write(self.bold_dir, entities, suffix="xfm", ext=".txt")
+        return self._add_fmriprep(
+            sub=sub,
+            ses=ses,
+            task=task,
+            run=run,
+            suffix="xfm",
+            ext=".txt",
+            sidecar_json=None,
+            **{"from": "T1w", "to": "scanner", "mode": "image"},  # `from` is reserved
+        )
 
     def add_bold_siblings(
         self,
         *,
-        sub: str = SUB,
+        sub: str,
         ses: str | None = None,
-        task: str | None = TASK,
+        task: str | None = None,
         run: str | None = None,
-        space: str = SPACE,
+        space: str,
     ) -> None:
         """Drop the full set of realistic fMRIPrep sibling files for a BOLD run."""
         self.add_boldref(sub=sub, ses=ses, task=task, run=run, space=space)
@@ -257,123 +305,3 @@ class BIDSTree:
 @pytest.fixture()
 def tree(tmp_path: Path) -> BIDSTree:
     return BIDSTree(tmp_path)
-
-
-# TODO: consolidate HyplineBIDSTree with BIDSTree
-class HyplineBIDSTree:
-    """Minimal on-disk fixture for BIDSLayout tests.
-
-    Matches the hypline BIDS tree layout; `ses` is optional in all helpers:
-        stimuli/sub-XX/[ses-YY/]<kind>/
-        features/sub-XX/[ses-YY/]<kind>/
-        derivatives/fmriprep/sub-XX/[ses-YY/]func/
-    """
-
-    def __init__(self, root: Path):
-        self.root = root
-
-    def _stem(self, entities: dict[str, str]) -> str:
-        return "_".join(f"{k}-{v}" for k, v in entities.items())
-
-    def _write(self, path: Path) -> Path:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch()
-        return path
-
-    def _entities(
-        self,
-        sub: str,
-        ses: str | None,
-        task: str | None,
-        run: str | None,
-        **extra: str,
-    ) -> dict[str, str]:
-        entities: dict[str, str] = {"sub": sub}
-        if ses is not None:
-            entities["ses"] = ses
-        if task is not None:
-            entities["task"] = task
-        if run is not None:
-            entities["run"] = run
-        entities.update(extra)
-        return entities
-
-    def add_stimulus(
-        self,
-        *,
-        kind: str,
-        ext: str,
-        sub: str,
-        ses: str | None = None,
-        task: str | None = None,
-        run: str | None = None,
-        **extra_entities: str,
-    ) -> Path:
-        entities = self._entities(sub, ses, task, run, **extra_entities)
-        entities["stim"] = kind
-        stem = self._stem(entities)
-        sub_dir = self.root / "stimuli" / f"sub-{sub}"
-        ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir
-        return self._write(ses_dir / kind / f"{stem}{ext}")
-
-    def add_feature(
-        self,
-        *,
-        kind: str,
-        sub: str,
-        ses: str | None = None,
-        task: str | None = None,
-        run: str | None = None,
-        **extra_entities: str,
-    ) -> Path:
-        entities = self._entities(sub, ses, task, run, **extra_entities)
-        entities["feat"] = kind
-        stem = self._stem(entities)
-        sub_dir = self.root / "features" / f"sub-{sub}"
-        ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir
-        return self._write(ses_dir / kind / f"{stem}.parquet")
-
-    def add_fmriprep(
-        self,
-        *,
-        suffix: str,
-        ext: str,
-        sub: str,
-        ses: str | None = None,
-        task: str | None = None,
-        run: str | None = None,
-        **extra_entities: str,
-    ) -> Path:
-        entities = self._entities(sub, ses, task, run, **extra_entities)
-        stem = self._stem(entities)
-        sub_dir = self.root / "derivatives" / "fmriprep" / f"sub-{sub}"
-        ses_dir = sub_dir / f"ses-{ses}" if ses is not None else sub_dir
-        return self._write(ses_dir / "func" / f"{stem}_{suffix}{ext}")
-
-    def add_fmriprep_bold(
-        self,
-        *,
-        space: str,
-        desc: str = "preproc",
-        sub: str,
-        ses: str | None = None,
-        task: str | None = None,
-        run: str | None = None,
-        **extra_entities: str,
-    ) -> Path:
-        return self.add_fmriprep(
-            suffix="bold",
-            ext=".nii.gz",
-            sub=sub,
-            ses=ses,
-            task=task,
-            run=run,
-            space=space,
-            desc=desc,
-            **extra_entities,
-        )
-
-
-@pytest.fixture()
-def layout_tree(tmp_path: Path) -> HyplineBIDSTree:
-    return HyplineBIDSTree(tmp_path)

--- a/tests/unit/test_bids.py
+++ b/tests/unit/test_bids.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 import pytest
 
-from hypline.bids import BIDSPath, validate_bids_entities
+from hypline.bids import (
+    BIDSPath,
+    find_bids_files,
+    normalize_bids_filters,
+    validate_bids_entities,
+    validate_entity_invariance,
+    validate_extension,
+)
 
 
 class TestBIDSPathParsing:
@@ -104,6 +111,18 @@ class TestBIDSPathWithEntity:
         _ = bp.with_entity("ses", "2")
         assert bp.ses == "1"
 
+    def test_new_entity_appended_at_end(self):
+        bp = BIDSPath("sub-01_ses-1_bold.nii")
+        bp2 = bp.with_entity("desc", "clean")
+        assert list(bp2.entities) == ["sub", "ses", "desc"]
+        assert bp2.path.name == "sub-01_ses-1_desc-clean_bold.nii"
+
+    def test_replaced_entity_keeps_position(self):
+        bp = BIDSPath("sub-01_ses-1_run-1_bold.nii")
+        bp2 = bp.with_entity("ses", "2")
+        assert list(bp2.entities) == ["sub", "ses", "run"]
+        assert bp2.path.name == "sub-01_ses-2_run-1_bold.nii"
+
     def test_with_entity_invalid_value(self):
         bp = BIDSPath("sub-01_bold.nii")
         with pytest.raises(ValueError, match="Invalid BIDS entity"):
@@ -140,6 +159,168 @@ class TestBIDSPathRepr:
     def test_repr(self):
         bp = BIDSPath("sub-01_bold.nii")
         assert repr(bp) == "BIDSPath('sub-01_bold.nii')"
+
+
+class TestBIDSPathComparison:
+    def test_equal_same_path(self):
+        assert BIDSPath("sub-01_bold.nii") == BIDSPath("sub-01_bold.nii")
+
+    def test_not_equal_different_path(self):
+        assert BIDSPath("sub-01_bold.nii") != BIDSPath("sub-02_bold.nii")
+
+    def test_hashable_in_set(self):
+        bp1 = BIDSPath("sub-01_bold.nii")
+        bp2 = BIDSPath("sub-01_bold.nii")
+        assert len({bp1, bp2}) == 1
+
+    def test_sortable(self):
+        bp1 = BIDSPath("sub-01_bold.nii")
+        bp2 = BIDSPath("sub-02_bold.nii")
+        assert bp1 < bp2
+        assert sorted([bp2, bp1]) == [bp1, bp2]
+
+    def test_lt_raises_for_non_bidspath(self):
+        bp = BIDSPath("sub-01_bold.nii")
+        with pytest.raises(TypeError):
+            _ = bp < "not-a-bidspath"  # type: ignore[arg-type]
+
+    def test_eq_returns_not_implemented_for_non_bidspath(self):
+        bp = BIDSPath("sub-01_bold.nii")
+        assert bp.__eq__("not-a-bidspath") is NotImplemented
+
+    def test_hash_consistent_with_eq(self):
+        bp1 = BIDSPath("sub-01_bold.nii")
+        bp2 = BIDSPath("sub-01_bold.nii")
+        assert bp1 == bp2
+        assert hash(bp1) == hash(bp2)
+
+
+class TestValidateExtension:
+    def test_valid_single(self):
+        validate_extension(".nii")
+
+    def test_valid_compound(self):
+        validate_extension(".nii.gz")
+        validate_extension(".func.gii")
+
+    def test_invalid_no_dot(self):
+        with pytest.raises(ValueError, match="Invalid extension"):
+            validate_extension("nii")
+
+    def test_invalid_dot_only(self):
+        with pytest.raises(ValueError, match="Invalid extension"):
+            validate_extension(".")
+
+    def test_invalid_special_chars(self):
+        with pytest.raises(ValueError, match="Invalid extension"):
+            validate_extension(".nii!")
+
+
+class TestNormalizeBidsFilters:
+    def test_returns_list_copy(self):
+        orig = ["sub-01"]
+        result = normalize_bids_filters(orig)
+        assert result == orig
+        assert result is not orig
+
+    def test_none_returns_empty_list(self):
+        assert normalize_bids_filters(None) == []
+
+    def test_rejects_invalid_entity(self):
+        with pytest.raises(ValueError, match="Invalid BIDS entity"):
+            normalize_bids_filters(["BAD"])
+
+    def test_rejects_reserved_key(self):
+        with pytest.raises(ValueError, match="sub"):
+            normalize_bids_filters(["sub-01"], reserved=["sub"])
+
+    def test_allows_non_reserved(self):
+        result = normalize_bids_filters(["task-rest", "ses-1"], reserved=["sub"])
+        assert result == ["task-rest", "ses-1"]
+
+
+class TestValidateEntityInvariance:
+    def test_passes_when_consistent(self):
+        paths = [BIDSPath("sub-01_ses-1_bold.nii"), BIDSPath("sub-01_ses-1_bold.nii")]
+        validate_entity_invariance(paths, ["sub", "ses"])
+
+    def test_raises_on_mismatch(self):
+        paths = [BIDSPath("sub-01_bold.nii"), BIDSPath("sub-02_bold.nii")]
+        with pytest.raises(ValueError, match="sub"):
+            validate_entity_invariance(paths, ["sub"])
+
+    def test_includes_none_in_display(self):
+        paths = [BIDSPath("sub-01_ses-1_bold.nii"), BIDSPath("sub-01_bold.nii")]
+        with pytest.raises(ValueError, match="ses"):
+            validate_entity_invariance(paths, ["ses"])
+
+
+class TestFindBidsFiles:
+    def test_finds_matching_files(self, tmp_path: Path):
+        (tmp_path / "sub-01_task-rest_bold.nii.gz").touch()
+        results = find_bids_files(tmp_path, ".nii.gz")
+        assert len(results) == 1
+        assert results[0].sub == "01"
+
+    def test_suffix_filter(self, tmp_path: Path):
+        (tmp_path / "sub-01_bold.nii.gz").touch()
+        (tmp_path / "sub-01_mask.nii.gz").touch()
+        results = find_bids_files(tmp_path, ".nii.gz", suffix="bold")
+        assert len(results) == 1
+        assert results[0].suffix == "bold"
+
+    def test_bids_filter_and(self, tmp_path: Path):
+        (tmp_path / "sub-01_task-rest_bold.nii.gz").touch()
+        (tmp_path / "sub-02_task-conv_bold.nii.gz").touch()
+        results = find_bids_files(
+            tmp_path, ".nii.gz", bids_filters=["sub-01", "task-rest"]
+        )
+        assert len(results) == 1
+        assert results[0].sub == "01"
+
+    def test_bids_filter_or_within_key(self, tmp_path: Path):
+        (tmp_path / "sub-01_bold.nii.gz").touch()
+        (tmp_path / "sub-02_bold.nii.gz").touch()
+        (tmp_path / "sub-03_bold.nii.gz").touch()
+        results = find_bids_files(
+            tmp_path, ".nii.gz", bids_filters=["sub-01", "sub-02"]
+        )
+        assert len(results) == 2
+
+    def test_bids_filter_and_with_or(self, tmp_path: Path):
+        (tmp_path / "sub-01_task-rest_bold.nii.gz").touch()
+        (tmp_path / "sub-02_task-rest_bold.nii.gz").touch()
+        (tmp_path / "sub-01_task-conv_bold.nii.gz").touch()
+        results = find_bids_files(
+            tmp_path, ".nii.gz", bids_filters=["sub-01", "sub-02", "task-rest"]
+        )
+        assert len(results) == 2
+        assert all(f.task == "rest" for f in results)
+
+    def test_skips_non_parseable(self, tmp_path: Path):
+        (tmp_path / "README.txt").touch()
+        (tmp_path / "sub-01_bold.nii.gz").touch()
+        results = find_bids_files(tmp_path, ".nii.gz")
+        assert len(results) == 1
+
+    def test_recursive(self, tmp_path: Path):
+        dir = tmp_path / "sub-01" / "func"
+        dir.mkdir(parents=True)
+        (dir / "sub-01_bold.nii.gz").touch()
+        assert find_bids_files(tmp_path, ".nii.gz") == []
+        results = find_bids_files(tmp_path, ".nii.gz", recursive=True)
+        assert len(results) == 1
+
+    def test_invalid_extension_raises(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Invalid extension"):
+            find_bids_files(tmp_path, "nii.gz")
+
+    def test_returns_sorted(self, tmp_path: Path):
+        (tmp_path / "sub-02_bold.nii.gz").touch()
+        (tmp_path / "sub-01_bold.nii.gz").touch()
+        results = find_bids_files(tmp_path, ".nii.gz")
+        assert len(results) == 2
+        assert results == sorted(results)
 
 
 class TestValidateBidsEntities:

--- a/tests/unit/test_bold.py
+++ b/tests/unit/test_bold.py
@@ -3,7 +3,11 @@ import pytest
 from hypline.bids import BIDSPath
 from hypline.bold import load_bold_meta, load_events_tsv
 
-from .conftest import SPACE, SUB, TASK, BIDSTree
+from .conftest import BIDSTree
+
+SUB = "001"
+TASK = "conv"
+SPACE = "MNI152NLin6Asym"
 
 
 class TestLoadEvents:
@@ -14,33 +18,33 @@ class TestLoadEvents:
     """
 
     def test_spec_compliant_events_returned(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        tree.add_events(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_events(sub=SUB, task=TASK, run="1")
         result = load_events_tsv(bold_path)
         assert result is not None
         assert "trial_type" in result.columns
 
     def test_no_events_returns_none(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         assert load_events_tsv(bold_path) is None
 
     def test_misnamed_sibling_with_space_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        events_path = tree.add_events(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        events_path = tree.add_events(sub=SUB, task=TASK, run="1")
         events_path.rename(BIDSPath(events_path).with_entity("space", SPACE).path)
         with pytest.raises(ValueError, match="unexpected events"):
             load_events_tsv(bold_path)
 
     def test_misnamed_sibling_with_desc_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        events_path = tree.add_events(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        events_path = tree.add_events(sub=SUB, task=TASK, run="1")
         events_path.rename(BIDSPath(events_path).with_entity("desc", "preproc").path)
         with pytest.raises(ValueError, match="unexpected events"):
             load_events_tsv(bold_path)
 
     def test_misnamed_sibling_with_space_and_desc_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        events_path = tree.add_events(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        events_path = tree.add_events(sub=SUB, task=TASK, run="1")
         events_path = events_path.rename(
             BIDSPath(events_path)
             .with_entity("space", SPACE)
@@ -51,16 +55,16 @@ class TestLoadEvents:
             load_events_tsv(bold_path)
 
     def test_misnamed_sibling_with_reordered_entities_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        events_path = tree.bold_dir / f"sub-{SUB}_run-1_task-{TASK}_events.tsv"
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        events_path = bold_path.parent / f"sub-{SUB}_run-1_task-{TASK}_events.tsv"
         events_path.write_text("trial_type\tonset\tduration\n")
         with pytest.raises(ValueError, match="unexpected events"):
             load_events_tsv(bold_path)
 
     def test_multiple_misnamed_siblings_all_listed(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         for space in (SPACE, "T1w"):
-            events_path = tree.add_events(run="1")
+            events_path = tree.add_events(sub=SUB, task=TASK, run="1")
             events_path.rename(BIDSPath(events_path).with_entity("space", space).path)
         with pytest.raises(ValueError) as exc_info:
             load_events_tsv(bold_path)
@@ -69,18 +73,19 @@ class TestLoadEvents:
         assert "T1w" in msg
 
     def test_unrelated_events_in_same_dir_ignored(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        tree.add_events(sub="002", run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        foreign = bold_path.parent / f"sub-002_task-{TASK}_run-1_events.tsv"
+        foreign.write_text("trial_type\tonset\tduration\n")
         assert load_events_tsv(bold_path) is None
 
     def test_different_run_events_in_same_dir_ignored(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        tree.add_events(run="2")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_events(sub=SUB, task=TASK, run="2")
         assert load_events_tsv(bold_path) is None
 
     def test_misnamed_sibling_for_different_run_ignored(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        events_path = tree.add_events(run="2")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        events_path = tree.add_events(sub=SUB, task=TASK, run="2")
         events_path.rename(BIDSPath(events_path).with_entity("space", SPACE).path)
         assert load_events_tsv(bold_path) is None
 
@@ -93,22 +98,28 @@ _SEGMENT_ROWS = [
 
 class TestLoadBoldMeta:
     def test_events_json_absent_passes(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        tree.add_events(run="1", rows=_SEGMENT_ROWS)
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_events(sub=SUB, task=TASK, run="1", rows=_SEGMENT_ROWS)
         meta = load_bold_meta(bold_path)
         assert all(seg.metadata == {} for seg in meta.segments)
 
     def test_events_json_without_trial_type_field_passes(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
-            run="1", rows=_SEGMENT_ROWS, events_json={"SomeOtherField": "value"}
+            sub=SUB,
+            task=TASK,
+            run="1",
+            rows=_SEGMENT_ROWS,
+            events_json={"SomeOtherField": "value"},
         )
         meta = load_bold_meta(bold_path)
         assert all(seg.metadata == {} for seg in meta.segments)
 
     def test_trial_type_field_without_levels_passes(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={"trial_type": {"LongName": "Type of trial"}},
@@ -117,8 +128,10 @@ class TestLoadBoldMeta:
         assert all(seg.metadata == {} for seg in meta.segments)
 
     def test_multiple_segment_entities_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -129,8 +142,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_identity_entity_as_segment_entity_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[{"trial_type": "run-2", "onset": 0.0, "duration": 200.0}],
         )
@@ -138,8 +153,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_task_segment_entity_multiple_rows_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": f"task-{TASK}", "onset": 0.0, "duration": 100.0},
@@ -150,8 +167,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_task_segment_value_matches_filename_passes(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[{"trial_type": f"task-{TASK}", "onset": 10.0, "duration": 180.0}],
         )
@@ -161,8 +180,10 @@ class TestLoadBoldMeta:
         assert meta.segments[0].value == TASK
 
     def test_task_segment_value_mismatches_filename_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[{"trial_type": "task-other", "onset": 0.0, "duration": 200.0}],
         )
@@ -170,8 +191,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_segment_entity_collides_with_flat_label_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -182,8 +205,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_duplicate_segment_value_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -194,8 +219,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_overlapping_segment_slices_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -206,8 +233,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_metadata_merged_into_segments(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -226,8 +255,10 @@ class TestLoadBoldMeta:
         assert by_value["2"].metadata == {"cond": "L"}
 
     def test_non_entity_value_levels_entries_ignored(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -243,8 +274,10 @@ class TestLoadBoldMeta:
         assert all(seg.metadata == {} for seg in meta.segments)
 
     def test_mixed_entity_and_non_entity_levels_entries(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -264,16 +297,20 @@ class TestLoadBoldMeta:
         assert by_value["2"].metadata == {"cond": "L"}
 
     def test_events_json_misnamed_sibling_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
-        events_path = tree.add_events(run="1", rows=_SEGMENT_ROWS, events_json={})
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        events_path = tree.add_events(
+            sub=SUB, task=TASK, run="1", rows=_SEGMENT_ROWS, events_json={}
+        )
         events_json = events_path.with_suffix(".json")
         events_json.rename(BIDSPath(events_json).with_entity("space", SPACE).path)
         with pytest.raises(ValueError, match="unexpected events"):
             load_bold_meta(bold_path)
 
     def test_events_json_with_segments_but_no_tsv_segments_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[{"trial_type": "rest", "onset": 0.0, "duration": 200.0}],
             events_json={
@@ -288,8 +325,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_levels_entry_missing_metadata_field_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -305,8 +344,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_events_json_segment_value_mismatch_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -322,8 +363,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_events_json_schema_mismatch_across_records_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -339,8 +382,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_events_json_extra_key_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -356,8 +401,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_events_json_reserved_key_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={
@@ -373,8 +420,10 @@ class TestLoadBoldMeta:
             load_bold_meta(bold_path)
 
     def test_events_json_invalid_value_raises(self, tree: BIDSTree):
-        bold_path = tree.add_bold(run="1")
+        bold_path = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=_SEGMENT_ROWS,
             events_json={

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -3,6 +3,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from hypline.encoding import BoldKey, CellKey, Encoding, EncodingConfig, FeatureKey
+from hypline.layout import BIDSLayout
 
 from .conftest import BIDSTree
 
@@ -18,14 +19,10 @@ def _make_encoding(
     bold_space: str = SPACE,
     bids_filters: list[str] | None = None,
 ) -> Encoding:
-    for d in (tree.features_dir, tree.fmriprep_dir, tree.results_dir):
-        d.mkdir(parents=True, exist_ok=True)
     return Encoding(
         EncodingConfig(),
+        layout=BIDSLayout(tree.root),
         features=features,
-        features_dir=tree.features_dir,
-        bold_dir=tree.fmriprep_dir,
-        output_dir=tree.results_dir,
         bold_space=bold_space,
         bids_filters=bids_filters,
     )
@@ -92,11 +89,9 @@ class TestDiscoverFeatures:
             enc._discover_features(SUB)
 
     def test_duplicate_feature_file_raises(self, tree: BIDSTree):
+        # Two filenames with identical BIDS entities (reordered) collide on FeatureKey
         original = tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
-        # Plant a second file with the same name in a nested subdir so recursive
-        # discovery returns two matches for the same (sub, kind, entities).
-        dup = original.parent / "dup" / original.name
-        dup.parent.mkdir(parents=True)
+        dup = original.parent / f"sub-{SUB}_run-1_task-{TASK}_feat-mfcc.parquet"
         dup.write_bytes(original.read_bytes())
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Multiple feature files"):
@@ -238,7 +233,7 @@ class TestDiscoverFeatures:
 
 class TestDiscoverBold:
     def test_returns_expected_keys(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses=None, run="1") in bold_metas
@@ -249,75 +244,69 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_duplicate_bold_raises(self, tree: BIDSTree):
-        original = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
-        dup = original.parent / "dup" / original.name
-        dup.parent.mkdir(parents=True)
-        dup.touch()
-        stem = original.name.removesuffix(".nii.gz")
-        (dup.parent / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
+        # Two filenames with identical BIDS entities (reordered) collide on BoldKey
+        original = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
+        dup_stem = f"sub-{SUB}_run-1_task-{TASK}_space-{SPACE}_desc-clean_bold"
+        (original.parent / f"{dup_stem}.nii.gz").touch()
+        (original.parent / f"{dup_stem}.json").write_text('{"RepetitionTime": 2.0}')
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Duplicate BOLD"):
             enc._discover_bold(SUB)
 
     def test_cross_session_runs_distinguished(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses="1", run="1")
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses="2", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses="1", run="1", desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses="2", run="1", desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses="1", run="1") in bold_metas
         assert BoldKey(ses="2", run="1") in bold_metas
 
     def test_bold_siblings_excluded(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         tree.add_bold_siblings(sub=SUB, task=TASK, space=SPACE, run="1")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_wrong_space_bold_excluded(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, run="1", space="MNI152NLin6Asym")
-        tree.add_bold(sub=SUB, task=TASK, run="1", space="T1w")
+        tree.add_bold(
+            sub=SUB, task=TASK, run="1", space="MNI152NLin6Asym", desc="clean"
+        )
+        tree.add_bold(sub=SUB, task=TASK, run="1", space="T1w", desc="clean")
         enc = _make_encoding(tree, ["mfcc"], bold_space="MNI152NLin6Asym")
         bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_inconsistent_tr_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=1.5)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=1.5, desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent repetition times"):
             enc._discover_bold(SUB)
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, space=SPACE, task="rest", run="1")
-        tree.add_bold(sub=SUB, space=SPACE, task="conv", run="2")
+        tree.add_bold(sub=SUB, space=SPACE, task="rest", run="1", desc="clean")
+        tree.add_bold(sub=SUB, space=SPACE, task="conv", run="2", desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
             enc._discover_bold(SUB)
 
     def test_acq_invariance_violation_raises(self, tree: BIDSTree):
-        for acq, run in (("hi", "1"), ("lo", "2")):
-            stem = (
-                f"sub-{SUB}_task-{TASK}_acq-{acq}_run-{run}_"
-                f"space-{SPACE}_desc-preproc_bold"
-            )
-            func = tree.func_dir(sub=SUB)
-            func.mkdir(parents=True, exist_ok=True)
-            (func / f"{stem}.nii.gz").touch()
-            (func / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean", acq="hi")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", desc="clean", acq="lo")
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="acq"):
             enc._discover_bold(SUB)
 
     def test_no_events_gives_no_segments(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         bold_meta = bold_metas[BoldKey(ses=None, run="1")]
         assert bold_meta.segments == []
 
     def test_structural_entity_slices_parsed(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -338,7 +327,7 @@ class TestDiscoverBold:
         assert bold_meta.segments[1].slice == slice(50, 100)
 
     def test_multiple_kv_entities_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -353,7 +342,7 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_segment_entity_as_flat_label_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -368,7 +357,7 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_duplicate_segment_values_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -383,7 +372,7 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_overlapping_slices_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -398,7 +387,7 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_leading_break_allowed(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -415,16 +404,20 @@ class TestDiscoverBold:
         assert bold_meta.segments[0].slice == slice(5, 50)
 
     def test_hyphen_free_trial_type_ignored(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
-        events_path = tree.func_dir(sub=SUB) / f"sub-{SUB}_task-{TASK}_run-1_events.tsv"
-        events_path.write_text("trial_type\tonset\tduration\nrest\t0.0\t100.0\n")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
+        tree.add_events(
+            sub=SUB,
+            task=TASK,
+            run="1",
+            rows=[{"trial_type": "rest", "onset": 0.0, "duration": 100.0}],
+        )
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         bold_meta = bold_metas[BoldKey(ses=None, run="1")]
         assert bold_meta.segments == []
 
     def test_kv_entity_with_gap_passes(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -440,7 +433,7 @@ class TestDiscoverBold:
         assert len(bold_meta.segments) == 2
 
     def test_flat_labels_alongside_segments_ignored(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -458,8 +451,8 @@ class TestDiscoverBold:
         assert bold_meta.segments[0].entity == "block"
 
     def test_runs_disagree_on_segment_entity_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -483,9 +476,9 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_mixed_segmented_and_unsegmented_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_bold(
-            sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0
+            sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0, desc="clean"
         )  # no events → unsegmented
         tree.add_events(
             sub=SUB,
@@ -505,8 +498,8 @@ class TestDiscoverBold:
             {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
             {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
         ]
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0, desc="clean")
 
         # run-1 has metadata key "cond"; run-2 has metadata key "item"
         tree.add_events(
@@ -543,15 +536,15 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_all_unsegmented_passes(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0, desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert all(bold_meta.segments == [] for bold_meta in bold_metas.values())
 
     def test_bids_filters_not_applied_at_discovery(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0, desc="clean")
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
         bold_metas = enc._discover_bold(SUB)
         assert len(bold_metas) == 2
@@ -563,7 +556,7 @@ class TestResolveCellKeys:
     def test_features_without_bold_raises(self, tree: BIDSTree):
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -573,7 +566,7 @@ class TestResolveCellKeys:
     def test_multiple_features_without_bold_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
             tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run=run)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -583,7 +576,7 @@ class TestResolveCellKeys:
     # Unsegmented run cases
 
     def test_unsegmented_run_single_cell_passes(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
@@ -593,7 +586,7 @@ class TestResolveCellKeys:
 
     def test_unsegmented_run_multiple_cells_raises(self, tree: BIDSTree):
         tree.add_bold(
-            sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0
+            sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean"
         )  # no events → unsegmented
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", trial="1")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", trial="2")
@@ -605,7 +598,7 @@ class TestResolveCellKeys:
 
     def test_extra_entity_on_unsegmented_run_raises(self, tree: BIDSTree):
         tree.add_bold(
-            sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0
+            sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean"
         )  # no events → unsegmented
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", trial="1")
         enc = _make_encoding(tree, ["mfcc"])
@@ -617,7 +610,7 @@ class TestResolveCellKeys:
     # Segmented run cases
 
     def test_valid_segmented_cells_pass(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -636,7 +629,7 @@ class TestResolveCellKeys:
         assert len(feature_paths) == 2
 
     def test_cell_missing_segment_entity_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -656,7 +649,7 @@ class TestResolveCellKeys:
             enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_cell_value_not_in_events_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -676,7 +669,7 @@ class TestResolveCellKeys:
             enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_extra_entity_on_segmented_run_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -697,7 +690,7 @@ class TestResolveCellKeys:
     # Metadata merge cases (filename × sidecar)
 
     def test_sidecar_only_metadata_merged_onto_cell_key(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -727,7 +720,7 @@ class TestResolveCellKeys:
         assert cell_cond_values == {"R", "L"}
 
     def test_filename_value_agrees_with_sidecar_passes(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -751,7 +744,7 @@ class TestResolveCellKeys:
         assert next(iter(feature_paths)).cell.get("cond") == "R"
 
     def test_filename_value_disagrees_with_sidecar_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -777,7 +770,7 @@ class TestResolveCellKeys:
 
 class TestApplyFilters:
     def test_no_filters_returns_unchanged(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -801,7 +794,9 @@ class TestApplyFilters:
 
     def test_filter_narrows_features(self, tree: BIDSTree):
         for run in ("1", "2"):
-            tree.add_bold(sub=SUB, task=TASK, space=SPACE, run=run, tr=2.0)
+            tree.add_bold(
+                sub=SUB, task=TASK, space=SPACE, run=run, tr=2.0, desc="clean"
+            )
             tree.add_events(
                 sub=SUB,
                 task=TASK,
@@ -825,7 +820,9 @@ class TestApplyFilters:
 
     def test_or_within_entity_and_across_entities(self, tree: BIDSTree):
         for ses, run in (("1", "1"), ("1", "2"), ("2", "1")):
-            tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses=ses, run=run, tr=2.0)
+            tree.add_bold(
+                sub=SUB, task=TASK, space=SPACE, ses=ses, run=run, tr=2.0, desc="clean"
+            )
             tree.add_events(
                 sub=SUB,
                 task=TASK,
@@ -852,7 +849,7 @@ class TestApplyFilters:
         assert BoldKey(ses="2", run="1") not in bold_metas
 
     def test_filter_on_bold_only_entity_skipped_on_features(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -867,7 +864,7 @@ class TestApplyFilters:
         enc = _make_encoding(
             tree,
             ["mfcc"],
-            bids_filters=["desc-preproc"],  # on BOLD filenames but not on CellKey
+            bids_filters=["desc-clean"],  # on BOLD filenames but not on CellKey
         )
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -877,7 +874,7 @@ class TestApplyFilters:
         assert len(bold_metas) == 1
 
     def test_filter_on_cell_only_entity_skipped_on_bold(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -910,7 +907,7 @@ class TestApplyFilters:
         assert len(bold_metas) == 1
 
     def test_typo_filter_entity_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -932,7 +929,7 @@ class TestApplyFilters:
     def test_valid_entity_wrong_value_passes_filter_raises_at_coverage(
         self, tree: BIDSTree
     ):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="clean")
         tree.add_events(
             sub=SUB,
             task=TASK,
@@ -955,7 +952,7 @@ class TestApplyFilters:
 
 class TestValidateCoverage:
     def test_valid_alignment_passes(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
@@ -965,7 +962,7 @@ class TestValidateCoverage:
         enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_cross_file_task_invariance_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, space=SPACE, task="conv", run="1")
+        tree.add_bold(sub=SUB, space=SPACE, task="conv", run="1", desc="clean")
         tree.add_feature(sub=SUB, task="rest", kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
@@ -976,7 +973,7 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_empty_features_after_filter_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
@@ -987,7 +984,7 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, {}, bold_metas)
 
     def test_empty_bold_after_filter_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
@@ -998,8 +995,8 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, feature_paths, {})
 
     def test_bold_without_features_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", desc="clean")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
@@ -1010,15 +1007,13 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_features_without_bold_after_filter_raises(self, tree: BIDSTree):
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="preproc")
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", desc="smooth")
+        # `res` is a BOLD-only entity (features carry no res), so filtering on it
+        # narrows BOLDs but not features, leaving run-2 features without a match
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="clean", res="2")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", desc="clean", res="3")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
-        enc = _make_encoding(
-            tree,
-            ["mfcc"],
-            bids_filters=["desc-preproc"],  # filters BOLD only (features carry no desc)
-        )
+        enc = _make_encoding(tree, ["mfcc"], bids_filters=["res-2"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
         feature_paths = enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
@@ -1028,10 +1023,10 @@ class TestValidateCoverage:
 
     def test_multiple_bold_gaps_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
-            tree.add_bold(sub=SUB, task=TASK, space=SPACE, run=run)
+            tree.add_bold(sub=SUB, task=TASK, space=SPACE, run=run, desc="clean")
             tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run=run)
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="4")
-        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="5")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="4", desc="clean")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="5", desc="clean")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -4,7 +4,11 @@ import pytest
 
 from hypline.encoding import BoldKey, CellKey, Encoding, EncodingConfig, FeatureKey
 
-from .conftest import SPACE, SUB, TASK, BIDSTree
+from .conftest import BIDSTree
+
+SUB = "001"
+TASK = "conv"
+SPACE = "MNI152NLin6Asym"
 
 
 def _make_encoding(
@@ -14,12 +18,14 @@ def _make_encoding(
     bold_space: str = SPACE,
     bids_filters: list[str] | None = None,
 ) -> Encoding:
+    for d in (tree.features_dir, tree.fmriprep_dir, tree.results_dir):
+        d.mkdir(parents=True, exist_ok=True)
     return Encoding(
         EncodingConfig(),
         features=features,
         features_dir=tree.features_dir,
-        bold_dir=tree.bold_dir,
-        output_dir=tree.output_dir,
+        bold_dir=tree.fmriprep_dir,
+        output_dir=tree.results_dir,
         bold_space=bold_space,
         bids_filters=bids_filters,
     )
@@ -74,7 +80,7 @@ class TestCellKey:
 
 class TestDiscoverFeatures:
     def test_returns_expected_keys(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         expected = FeatureKey(cell=CellKey(run="1"), feature="mfcc")
@@ -86,45 +92,51 @@ class TestDiscoverFeatures:
             enc._discover_features(SUB)
 
     def test_duplicate_feature_file_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        tree.add_feature("mfcc", run="1", subdir="sub")
+        original = tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
+        # Plant a second file with the same name in a nested subdir so recursive
+        # discovery returns two matches for the same (sub, kind, entities).
+        dup = original.parent / "dup" / original.name
+        dup.parent.mkdir(parents=True)
+        dup.write_bytes(original.read_bytes())
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Multiple feature files"):
             enc._discover_features(SUB)
 
     def test_missing_feature_at_one_cell_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        tree.add_feature("mfcc", run="2")
-        tree.add_feature("clip", run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="clip", run="1")
         enc = _make_encoding(tree, ["mfcc", "clip"])
         with pytest.raises(FileNotFoundError, match="Missing feature=clip"):
             enc._discover_features(SUB)
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", task="rest", run="1")
-        tree.add_feature("mfcc", task="conv", run="2")
+        tree.add_feature(sub=SUB, task="rest", kind="mfcc", run="1")
+        tree.add_feature(sub=SUB, task="conv", kind="mfcc", run="2")
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
             enc._discover_features(SUB)
 
     def test_mixed_segmented_unsegmented_runs_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent feature file schemas"):
             enc._discover_features(SUB)
 
     def test_schema_error_fires_before_coverage_error(self, tree: BIDSTree):
         # clip missing at run-2, but schema mismatch should raise first
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="2")
-        tree.add_feature("clip", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="clip", run="1", block="1")
         enc = _make_encoding(tree, ["mfcc", "clip"])
         with pytest.raises(ValueError, match="Inconsistent feature file schemas"):
             enc._discover_features(SUB)
 
     def test_file_without_hypline_metadata_raises(self, tree: BIDSTree, tmp_path):
-        path = tree.features_dir / f"sub-{SUB}_task-{TASK}_run-1_feat-mfcc.parquet"
+        kind_dir = tree.features_dir / f"sub-{SUB}" / "mfcc"
+        kind_dir.mkdir(parents=True)
+        path = kind_dir / f"sub-{SUB}_task-{TASK}_run-1_feat-mfcc.parquet"
         df = pl.DataFrame({"start_time": [0.0], "feature": [[0.0]]})
         pq.write_table(df.to_arrow(), path)
         enc = _make_encoding(tree, ["mfcc"])
@@ -132,59 +144,101 @@ class TestDiscoverFeatures:
             enc._discover_features(SUB)
 
     def test_bids_filters_not_applied_at_discovery(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        tree.add_feature("mfcc", run="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
         feature_paths = enc._discover_features(SUB)
         assert len(feature_paths) == 2
 
     def test_inconsistent_metadata_across_files_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", metadata={"model": "v1"})
-        tree.add_feature("mfcc", run="2", metadata={"model": "v2"})
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="2", metadata={"model": "v2"}
+        )
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent metadata for feature=mfcc"):
             enc._discover_features(SUB)
 
     def test_inconsistent_metadata_diff_in_error_message(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", metadata={"model": "v1"})
-        tree.add_feature("mfcc", run="2", metadata={"model": "v2"})
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="2", metadata={"model": "v2"}
+        )
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="model:"):
             enc._discover_features(SUB)
 
     def test_missing_key_shows_as_missing_in_diff(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", metadata={"model": "v1"})
-        tree.add_feature("mfcc", run="2", metadata={"model": "v1", "extra": "x"})
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB,
+            task=TASK,
+            kind="mfcc",
+            run="2",
+            metadata={"model": "v1", "extra": "x"},
+        )
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="<missing>"):
             enc._discover_features(SUB)
 
     def test_third_file_diverges_from_first(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", metadata={"model": "v1"})
-        tree.add_feature("mfcc", run="2", metadata={"model": "v1"})
-        tree.add_feature("mfcc", run="3", metadata={"model": "v2"})
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="2", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="3", metadata={"model": "v2"}
+        )
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent metadata for feature=mfcc"):
             enc._discover_features(SUB)
 
     def test_underscore_prefixed_keys_exempt_from_metadata_check(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", metadata={"model": "v1", "_run_id": "abc"})
-        tree.add_feature("mfcc", run="2", metadata={"model": "v1", "_run_id": "xyz"})
+        tree.add_feature(
+            sub=SUB,
+            task=TASK,
+            kind="mfcc",
+            run="1",
+            metadata={"model": "v1", "_run_id": "abc"},
+        )
+        tree.add_feature(
+            sub=SUB,
+            task=TASK,
+            kind="mfcc",
+            run="2",
+            metadata={"model": "v1", "_run_id": "xyz"},
+        )
         enc = _make_encoding(tree, ["mfcc"])
         enc._discover_features(SUB)
 
     def test_metadata_check_independent_across_features(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1", metadata={"model": "v1"})
-        tree.add_feature("mfcc", run="2", metadata={"model": "v1"})
-        tree.add_feature("clip", run="1", metadata={"model": "v2"})
-        tree.add_feature("clip", run="2", metadata={"model": "v2"})
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="2", metadata={"model": "v1"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="clip", run="1", metadata={"model": "v2"}
+        )
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="clip", run="2", metadata={"model": "v2"}
+        )
         enc = _make_encoding(tree, ["mfcc", "clip"])
         enc._discover_features(SUB)
 
 
 class TestDiscoverBold:
     def test_returns_expected_keys(self, tree: BIDSTree):
-        tree.add_bold(run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses=None, run="1") in bold_metas
@@ -195,44 +249,48 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_duplicate_bold_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1")
-        tree.add_bold(run="1", subdir="sub")
+        original = tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        dup = original.parent / "dup" / original.name
+        dup.parent.mkdir(parents=True)
+        dup.touch()
+        stem = original.name.removesuffix(".nii.gz")
+        (dup.parent / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Duplicate BOLD"):
             enc._discover_bold(SUB)
 
     def test_cross_session_runs_distinguished(self, tree: BIDSTree):
-        tree.add_bold(ses="1", run="1")
-        tree.add_bold(ses="2", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses="1", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses="2", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert BoldKey(ses="1", run="1") in bold_metas
         assert BoldKey(ses="2", run="1") in bold_metas
 
     def test_bold_siblings_excluded(self, tree: BIDSTree):
-        tree.add_bold(run="1")
-        tree.add_bold_siblings(run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold_siblings(sub=SUB, task=TASK, space=SPACE, run="1")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_wrong_space_bold_excluded(self, tree: BIDSTree):
-        tree.add_bold(run="1", space="MNI152NLin6Asym")
-        tree.add_bold(run="1", space="T1w")
+        tree.add_bold(sub=SUB, task=TASK, run="1", space="MNI152NLin6Asym")
+        tree.add_bold(sub=SUB, task=TASK, run="1", space="T1w")
         enc = _make_encoding(tree, ["mfcc"], bold_space="MNI152NLin6Asym")
         bold_metas = enc._discover_bold(SUB)
         assert list(bold_metas.keys()) == [BoldKey(ses=None, run="1")]
 
     def test_inconsistent_tr_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=1.5)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=1.5)
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="Inconsistent repetition times"):
             enc._discover_bold(SUB)
 
     def test_task_invariance_violation_raises(self, tree: BIDSTree):
-        tree.add_bold(task="rest", run="1")
-        tree.add_bold(task="conv", run="2")
+        tree.add_bold(sub=SUB, space=SPACE, task="rest", run="1")
+        tree.add_bold(sub=SUB, space=SPACE, task="conv", run="2")
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="task"):
             enc._discover_bold(SUB)
@@ -243,22 +301,26 @@ class TestDiscoverBold:
                 f"sub-{SUB}_task-{TASK}_acq-{acq}_run-{run}_"
                 f"space-{SPACE}_desc-preproc_bold"
             )
-            (tree.bold_dir / f"{stem}.nii.gz").touch()
-            (tree.bold_dir / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
+            func = tree.func_dir(sub=SUB)
+            func.mkdir(parents=True, exist_ok=True)
+            (func / f"{stem}.nii.gz").touch()
+            (func / f"{stem}.json").write_text('{"RepetitionTime": 2.0}')
         enc = _make_encoding(tree, ["mfcc"])
         with pytest.raises(ValueError, match="acq"):
             enc._discover_bold(SUB)
 
     def test_no_events_gives_no_segments(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         bold_meta = bold_metas[BoldKey(ses=None, run="1")]
         assert bold_meta.segments == []
 
     def test_structural_entity_slices_parsed(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -276,8 +338,10 @@ class TestDiscoverBold:
         assert bold_meta.segments[1].slice == slice(50, 100)
 
     def test_multiple_kv_entities_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -289,8 +353,10 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_segment_entity_as_flat_label_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -302,8 +368,10 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_duplicate_segment_values_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -315,8 +383,10 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_overlapping_slices_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 120.0},
@@ -328,8 +398,10 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_leading_break_allowed(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 10.0, "duration": 90.0},
@@ -343,8 +415,8 @@ class TestDiscoverBold:
         assert bold_meta.segments[0].slice == slice(5, 50)
 
     def test_hyphen_free_trial_type_ignored(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        events_path = tree.bold_dir / f"sub-{SUB}_task-{TASK}_run-1_events.tsv"
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        events_path = tree.func_dir(sub=SUB) / f"sub-{SUB}_task-{TASK}_run-1_events.tsv"
         events_path.write_text("trial_type\tonset\tduration\nrest\t0.0\t100.0\n")
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
@@ -352,8 +424,10 @@ class TestDiscoverBold:
         assert bold_meta.segments == []
 
     def test_kv_entity_with_gap_passes(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -366,8 +440,10 @@ class TestDiscoverBold:
         assert len(bold_meta.segments) == 2
 
     def test_flat_labels_alongside_segments_ignored(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -382,9 +458,11 @@ class TestDiscoverBold:
         assert bold_meta.segments[0].entity == "block"
 
     def test_runs_disagree_on_segment_entity_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -392,6 +470,8 @@ class TestDiscoverBold:
             ],
         )
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="2",
             rows=[
                 {"trial_type": "trial-1", "onset": 0.0, "duration": 100.0},
@@ -403,9 +483,13 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_mixed_segmented_and_unsegmented_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=2.0)  # no events → unsegmented
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(
+            sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0
+        )  # no events → unsegmented
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -421,11 +505,13 @@ class TestDiscoverBold:
             {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
             {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
         ]
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
 
         # run-1 has metadata key "cond"; run-2 has metadata key "item"
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=rows,
             events_json={
@@ -438,6 +524,8 @@ class TestDiscoverBold:
             },
         )
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="2",
             rows=rows,
             events_json={
@@ -455,15 +543,15 @@ class TestDiscoverBold:
             enc._discover_bold(SUB)
 
     def test_all_unsegmented_passes(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
         enc = _make_encoding(tree, ["mfcc"])
         bold_metas = enc._discover_bold(SUB)
         assert all(bold_meta.segments == [] for bold_meta in bold_metas.values())
 
     def test_bids_filters_not_applied_at_discovery(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_bold(run="2", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", tr=2.0)
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
         bold_metas = enc._discover_bold(SUB)
         assert len(bold_metas) == 2
@@ -473,9 +561,9 @@ class TestResolveCellKeys:
     # Orphan check (feature cell has no matching BOLD run)
 
     def test_features_without_bold_raises(self, tree: BIDSTree):
-        tree.add_feature("mfcc", run="1")
-        tree.add_feature("mfcc", run="2")
-        tree.add_bold(run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -484,8 +572,8 @@ class TestResolveCellKeys:
 
     def test_multiple_features_without_bold_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
-            tree.add_feature("mfcc", run=run)
-        tree.add_bold(run="1")
+            tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run=run)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -495,8 +583,8 @@ class TestResolveCellKeys:
     # Unsegmented run cases
 
     def test_unsegmented_run_single_cell_passes(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
-        tree.add_feature("mfcc", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -504,9 +592,11 @@ class TestResolveCellKeys:
         assert len(feature_paths) == 1
 
     def test_unsegmented_run_multiple_cells_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
-        tree.add_feature("mfcc", run="1", trial="1")
-        tree.add_feature("mfcc", run="1", trial="2")
+        tree.add_bold(
+            sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0
+        )  # no events → unsegmented
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", trial="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", trial="2")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -514,8 +604,10 @@ class TestResolveCellKeys:
             enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_extra_entity_on_unsegmented_run_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)  # no events → unsegmented
-        tree.add_feature("mfcc", run="1", trial="1")
+        tree.add_bold(
+            sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0
+        )  # no events → unsegmented
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", trial="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -525,16 +617,18 @@ class TestResolveCellKeys:
     # Segmented run cases
 
     def test_valid_segmented_cells_pass(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -542,15 +636,19 @@ class TestResolveCellKeys:
         assert len(feature_paths) == 2
 
     def test_cell_missing_segment_entity_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1")  # no block entity on the filename
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1"
+        )  # no block entity on the filename
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -558,15 +656,19 @@ class TestResolveCellKeys:
             enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_cell_value_not_in_events_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="3")  # block-3 not in events
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", block="3"
+        )  # block-3 not in events
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -574,14 +676,18 @@ class TestResolveCellKeys:
             enc._resolve_cell_keys(SUB, feature_paths, bold_metas)
 
     def test_extra_entity_on_segmented_run_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="1", extra="foo")
+        tree.add_feature(
+            sub=SUB, task=TASK, kind="mfcc", run="1", block="1", extra="foo"
+        )
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -591,8 +697,10 @@ class TestResolveCellKeys:
     # Metadata merge cases (filename × sidecar)
 
     def test_sidecar_only_metadata_merged_onto_cell_key(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -607,8 +715,8 @@ class TestResolveCellKeys:
                 }
             },
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -619,8 +727,10 @@ class TestResolveCellKeys:
         assert cell_cond_values == {"R", "L"}
 
     def test_filename_value_agrees_with_sidecar_passes(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -633,7 +743,7 @@ class TestResolveCellKeys:
                 }
             },
         )
-        tree.add_feature("mfcc", run="1", block="1", cond="R")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1", cond="R")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -641,8 +751,10 @@ class TestResolveCellKeys:
         assert next(iter(feature_paths)).cell.get("cond") == "R"
 
     def test_filename_value_disagrees_with_sidecar_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -655,7 +767,7 @@ class TestResolveCellKeys:
                 }
             },
         )
-        tree.add_feature("mfcc", run="1", block="1", cond="L")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1", cond="L")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -665,16 +777,18 @@ class TestResolveCellKeys:
 
 class TestApplyFilters:
     def test_no_filters_returns_unchanged(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -687,18 +801,20 @@ class TestApplyFilters:
 
     def test_filter_narrows_features(self, tree: BIDSTree):
         for run in ("1", "2"):
-            tree.add_bold(run=run, tr=2.0)
+            tree.add_bold(sub=SUB, task=TASK, space=SPACE, run=run, tr=2.0)
             tree.add_events(
+                sub=SUB,
+                task=TASK,
                 run=run,
                 rows=[
                     {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                     {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
                 ],
             )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
-        tree.add_feature("mfcc", run="2", block="1")
-        tree.add_feature("mfcc", run="2", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2", block="2")
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["run-1"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -709,15 +825,19 @@ class TestApplyFilters:
 
     def test_or_within_entity_and_across_entities(self, tree: BIDSTree):
         for ses, run in (("1", "1"), ("1", "2"), ("2", "1")):
-            tree.add_bold(ses=ses, run=run, tr=2.0)
+            tree.add_bold(sub=SUB, task=TASK, space=SPACE, ses=ses, run=run, tr=2.0)
             tree.add_events(
+                sub=SUB,
+                task=TASK,
                 ses=ses,
                 run=run,
                 rows=[
                     {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 ],
             )
-            tree.add_feature("mfcc", ses=ses, run=run, block="1")
+            tree.add_feature(
+                sub=SUB, task=TASK, kind="mfcc", ses=ses, run=run, block="1"
+            )
         enc = _make_encoding(
             tree,
             ["mfcc"],
@@ -732,16 +852,18 @@ class TestApplyFilters:
         assert BoldKey(ses="2", run="1") not in bold_metas
 
     def test_filter_on_bold_only_entity_skipped_on_features(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(
             tree,
             ["mfcc"],
@@ -755,8 +877,10 @@ class TestApplyFilters:
         assert len(bold_metas) == 1
 
     def test_filter_on_cell_only_entity_skipped_on_bold(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
@@ -771,8 +895,8 @@ class TestApplyFilters:
                 }
             },
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(
             tree,
             ["mfcc"],
@@ -786,16 +910,18 @@ class TestApplyFilters:
         assert len(bold_metas) == 1
 
     def test_typo_filter_entity_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["typo-foo"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -806,16 +932,18 @@ class TestApplyFilters:
     def test_valid_entity_wrong_value_passes_filter_raises_at_coverage(
         self, tree: BIDSTree
     ):
-        tree.add_bold(run="1", tr=2.0)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0)
         tree.add_events(
+            sub=SUB,
+            task=TASK,
             run="1",
             rows=[
                 {"trial_type": "block-1", "onset": 0.0, "duration": 100.0},
                 {"trial_type": "block-2", "onset": 100.0, "duration": 100.0},
             ],
         )
-        tree.add_feature("mfcc", run="1", block="1")
-        tree.add_feature("mfcc", run="1", block="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1", block="2")
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["block-99"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -827,8 +955,8 @@ class TestApplyFilters:
 
 class TestValidateCoverage:
     def test_valid_alignment_passes(self, tree: BIDSTree):
-        tree.add_bold(run="1")
-        tree.add_feature("mfcc", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -837,8 +965,8 @@ class TestValidateCoverage:
         enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_cross_file_task_invariance_raises(self, tree: BIDSTree):
-        tree.add_bold(task="conv", run="1")
-        tree.add_feature("mfcc", task="rest", run="1")
+        tree.add_bold(sub=SUB, space=SPACE, task="conv", run="1")
+        tree.add_feature(sub=SUB, task="rest", kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -848,8 +976,8 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_empty_features_after_filter_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1")
-        tree.add_feature("mfcc", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -859,8 +987,8 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, {}, bold_metas)
 
     def test_empty_bold_after_filter_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1")
-        tree.add_feature("mfcc", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -870,9 +998,9 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, feature_paths, {})
 
     def test_bold_without_features_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1")
-        tree.add_bold(run="2")
-        tree.add_feature("mfcc", run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)
@@ -882,10 +1010,10 @@ class TestValidateCoverage:
             enc._validate_coverage(SUB, feature_paths, bold_metas)
 
     def test_features_without_bold_after_filter_raises(self, tree: BIDSTree):
-        tree.add_bold(run="1", desc="preproc")
-        tree.add_bold(run="2", desc="smooth")
-        tree.add_feature("mfcc", run="1")
-        tree.add_feature("mfcc", run="2")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", desc="preproc")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="2", desc="smooth")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="1")
+        tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run="2")
         enc = _make_encoding(
             tree,
             ["mfcc"],
@@ -900,10 +1028,10 @@ class TestValidateCoverage:
 
     def test_multiple_bold_gaps_reports_count(self, tree: BIDSTree):
         for run in ("1", "2", "3"):
-            tree.add_bold(run=run)
-            tree.add_feature("mfcc", run=run)
-        tree.add_bold(run="4")
-        tree.add_bold(run="5")
+            tree.add_bold(sub=SUB, task=TASK, space=SPACE, run=run)
+            tree.add_feature(sub=SUB, task=TASK, kind="mfcc", run=run)
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="4")
+        tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="5")
         enc = _make_encoding(tree, ["mfcc"])
         feature_paths = enc._discover_features(SUB)
         bold_metas = enc._discover_bold(SUB)

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -124,7 +124,7 @@ class TestDiscoverFeatures:
             enc._discover_features(SUB)
 
     def test_file_without_hypline_metadata_raises(self, tree: BIDSTree, tmp_path):
-        path = tree.features_dir / f"sub-{SUB}_task-{TASK}_run-1_feature-mfcc.parquet"
+        path = tree.features_dir / f"sub-{SUB}_task-{TASK}_run-1_feat-mfcc.parquet"
         df = pl.DataFrame({"start_time": [0.0], "feature": [[0.0]]})
         pq.write_table(df.to_arrow(), path)
         enc = _make_encoding(tree, ["mfcc"])

--- a/tests/unit/test_feature_utils.py
+++ b/tests/unit/test_feature_utils.py
@@ -19,7 +19,7 @@ from hypline.features._utils import (
 
 @pytest.fixture()
 def feature_path(tmp_path: Path) -> Path:
-    return tmp_path / "sub-01_ses-1_feature-mfcc.parquet"
+    return tmp_path / "sub-01_ses-1_feat-mfcc.parquet"
 
 
 @pytest.fixture()
@@ -40,7 +40,7 @@ class TestSaveFeature:
         assert df.equals(sample_df)
 
     def test_creates_parent_dirs(self, tmp_path: Path, sample_df: pl.DataFrame):
-        path = tmp_path / "a" / "b" / "sub-01_feature-mfcc.parquet"
+        path = tmp_path / "a" / "b" / "sub-01_feat-mfcc.parquet"
         save_feature(sample_df, path)
         assert path.exists()
 
@@ -123,16 +123,16 @@ class TestSaveFeature:
         self, tmp_path: Path, sample_df: pl.DataFrame
     ):
         path = tmp_path / "sub-01_ses-1_bold.parquet"
-        with pytest.raises(ValueError, match="must contain a 'feature' entity"):
+        with pytest.raises(ValueError, match="must contain a 'feat' entity"):
             save_feature(sample_df, path)
 
     def test_non_parquet_extension(self, tmp_path: Path, sample_df: pl.DataFrame):
-        path = tmp_path / "sub-01_feature-mfcc_bold.tsv"
+        path = tmp_path / "sub-01_feat-mfcc_bold.tsv"
         with pytest.raises(ValueError, match=".parquet extension"):
             save_feature(sample_df, path)
 
     def test_rejects_bids_suffix(self, tmp_path: Path, sample_df: pl.DataFrame):
-        path = tmp_path / "sub-01_feature-mfcc_bold.parquet"
+        path = tmp_path / "sub-01_feat-mfcc_bold.parquet"
         with pytest.raises(ValueError, match="must not have a BIDS suffix"):
             save_feature(sample_df, path)
 
@@ -140,11 +140,11 @@ class TestSaveFeature:
 class TestReadFeatureMetadata:
     def test_missing_feature_entity(self, tmp_path: Path):
         path = tmp_path / "sub-01.parquet"
-        with pytest.raises(ValueError, match="must contain a 'feature' entity"):
+        with pytest.raises(ValueError, match="must contain a 'feat' entity"):
             read_feature_metadata(path)
 
     def test_rejects_bids_suffix(self, tmp_path: Path):
-        path = tmp_path / "sub-01_feature-mfcc_bold.parquet"
+        path = tmp_path / "sub-01_feat-mfcc_bold.parquet"
         with pytest.raises(ValueError, match="must not have a BIDS suffix"):
             read_feature_metadata(path)
 
@@ -158,8 +158,8 @@ class TestReadFeatureMetadata:
     def test_feature_name_mismatch_raises(
         self, tmp_path: Path, sample_df: pl.DataFrame
     ):
-        src = tmp_path / "sub-01_feature-phonemic.parquet"
-        dst = tmp_path / "sub-01_feature-mfcc.parquet"
+        src = tmp_path / "sub-01_feat-phonemic.parquet"
+        dst = tmp_path / "sub-01_feat-mfcc.parquet"
         save_feature(sample_df, src)
         shutil.copy(src, dst)
         with pytest.raises(ValueError, match="does not match path entity"):
@@ -177,7 +177,7 @@ class TestReadFeatureMetadata:
 
 def _write_raw_feature(df: pl.DataFrame, path: Path) -> None:
     """Write a parquet with hypline metadata, bypassing save_feature validation."""
-    feature_name = BIDSPath(path).entities["feature"]
+    feature_name = BIDSPath(path).entities["feat"]
     table = df.to_arrow().replace_schema_metadata(
         {b"hypline": json.dumps({"feature_name": feature_name}).encode()}
     )
@@ -187,16 +187,16 @@ def _write_raw_feature(df: pl.DataFrame, path: Path) -> None:
 class TestReadFeature:
     def test_missing_feature_entity(self, tmp_path: Path):
         path = tmp_path / "sub-01_bold.parquet"
-        with pytest.raises(ValueError, match="must contain a 'feature' entity"):
+        with pytest.raises(ValueError, match="must contain a 'feat' entity"):
             read_feature(path)
 
     def test_non_parquet_extension(self, tmp_path: Path):
-        path = tmp_path / "sub-01_feature-mfcc_bold.tsv"
+        path = tmp_path / "sub-01_feat-mfcc_bold.tsv"
         with pytest.raises(ValueError, match=".parquet extension"):
             read_feature(path)
 
     def test_rejects_bids_suffix(self, tmp_path: Path):
-        path = tmp_path / "sub-01_feature-mfcc_bold.parquet"
+        path = tmp_path / "sub-01_feat-mfcc_bold.parquet"
         with pytest.raises(ValueError, match="must not have a BIDS suffix"):
             read_feature(path)
 
@@ -250,8 +250,8 @@ class TestReadFeature:
     def test_feature_name_mismatch_raises(
         self, tmp_path: Path, sample_df: pl.DataFrame
     ):
-        src = tmp_path / "sub-01_feature-phonemic.parquet"
-        dst = tmp_path / "sub-01_feature-mfcc.parquet"
+        src = tmp_path / "sub-01_feat-phonemic.parquet"
+        dst = tmp_path / "sub-01_feat-mfcc.parquet"
         save_feature(sample_df, src)
         shutil.copy(src, dst)
         with pytest.raises(ValueError, match="does not match path entity"):

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -109,7 +109,7 @@ class TestFindFeatures:
         layout = BIDSLayout(layout_tree.root)
         results = layout.find.features(sub=SUB, kind="phonemic")
         assert len(results) == 1
-        assert results[0].entities.get("feature") == "phonemic"
+        assert results[0].entities.get("feat") == "phonemic"
 
     def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
         layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
@@ -136,9 +136,9 @@ class TestFindFeatures:
 
     def test_rejects_reserved_feature_filter(self, layout_tree: HyplineBIDSTree):
         layout = BIDSLayout(layout_tree.root)
-        with pytest.raises(ValueError, match="feature"):
+        with pytest.raises(ValueError, match="feat"):
             layout.find.features(
-                sub=SUB, kind="phonemic", bids_filters=["feature-phonemic"]
+                sub=SUB, kind="phonemic", bids_filters=["feat-phonemic"]
             )
 
     def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
@@ -323,7 +323,7 @@ class TestBuildFeature:
         layout = BIDSLayout(tmp_path)
         source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-transcript.csv")
         out = layout.build.feature(source=source, kind="phonemic")
-        assert out.entities.get("feature") == "phonemic"
+        assert out.entities.get("feat") == "phonemic"
         assert out.path.suffix == ".parquet"
         assert "features" in out.path.parts
         assert f"sub-{SUB}" in out.path.parts

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -5,7 +5,7 @@ import pytest
 from hypline.bids import BIDSPath
 from hypline.layout import BIDSLayout
 
-from .conftest import HyplineBIDSTree
+from .conftest import BIDSTree
 
 SUB = "001"
 SES = "1"
@@ -24,46 +24,46 @@ class TestBIDSLayoutConstruction:
 
 
 class TestFindStimuli:
-    def test_returns_matching_files(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_returns_matching_files(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(sub=SUB, kind="audio", ext=".wav")
         assert len(results) == 1
         assert results[0].sub == SUB
 
-    def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_returns_empty_when_sub_absent(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(sub="999", kind="audio", ext=".wav")
         assert results == []
 
-    def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_ses_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(
             sub=SUB, kind="audio", ext=".wav", bids_filters=["ses-1"]
         )
         assert len(results) == 1
         assert results[0].ses == "1"
 
-    def test_arbitrary_bids_filter(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task="conv")
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task="rest")
-        layout = BIDSLayout(layout_tree.root)
+    def test_arbitrary_bids_filter(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task="conv")
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task="rest")
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(
             sub=SUB, kind="audio", ext=".wav", bids_filters=["task-conv"]
         )
         assert len(results) == 1
 
-    def test_rejects_reserved_sub_filter(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_rejects_reserved_sub_filter(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         with pytest.raises(ValueError, match="sub"):
             layout.find.stimuli(
                 sub=SUB, kind="audio", ext=".wav", bids_filters=["sub-001"]
             )
 
-    def test_rejects_reserved_stim_filter(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_rejects_reserved_stim_filter(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         with pytest.raises(ValueError, match="stim"):
             layout.find.stimuli(
                 sub=SUB, kind="audio", ext=".wav", bids_filters=["stim-audio"]
@@ -73,29 +73,29 @@ class TestFindStimuli:
         layout = BIDSLayout(tmp_path)
         assert layout.find.stimuli(sub=SUB, kind="audio", ext=".wav") == []
 
-    def test_run_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK, run="1")
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK, run="2")
-        layout = BIDSLayout(layout_tree.root)
+    def test_run_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK, run="1")
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK, run="2")
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(
             sub=SUB, kind="audio", ext=".wav", bids_filters=["run-1"]
         )
         assert len(results) == 1
         assert results[0].entities.get("run") == "1"
 
-    def test_cross_session_aggregation_sorted(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_cross_session_aggregation_sorted(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(sub=SUB, kind="audio", ext=".wav")
         assert len(results) == 2
         assert results == sorted(results)
 
-    def test_multiple_ses_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="3", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_multiple_ses_filters(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="3", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.stimuli(
             sub=SUB, kind="audio", ext=".wav", bids_filters=["ses-1", "ses-2"]
         )
@@ -104,72 +104,72 @@ class TestFindStimuli:
 
 
 class TestFindFeatures:
-    def test_translates_kind_to_feature_entity(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_translates_kind_to_feature_entity(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.features(sub=SUB, kind="phonemic")
         assert len(results) == 1
         assert results[0].entities.get("feat") == "phonemic"
 
-    def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_ses_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.features(sub=SUB, kind="phonemic", bids_filters=["ses-1"])
         assert len(results) == 1
         assert results[0].ses == "1"
 
-    def test_arbitrary_bids_filter(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK, desc="gpt3")
-        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_arbitrary_bids_filter(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, task=TASK, desc="gpt3")
+        tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.features(
             sub=SUB, kind="phonemic", bids_filters=["desc-gpt3"]
         )
         assert len(results) == 1
         assert results[0].entities.get("desc") == "gpt3"
 
-    def test_rejects_reserved_sub_filter(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_rejects_reserved_sub_filter(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         with pytest.raises(ValueError, match="sub"):
             layout.find.features(sub=SUB, kind="phonemic", bids_filters=["sub-001"])
 
-    def test_rejects_reserved_feature_filter(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_rejects_reserved_feature_filter(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         with pytest.raises(ValueError, match="feat"):
             layout.find.features(
                 sub=SUB, kind="phonemic", bids_filters=["feat-phonemic"]
             )
 
-    def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_returns_empty_when_sub_absent(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         assert layout.find.features(sub="999", kind="phonemic") == []
 
     def test_empty_if_area_absent(self, tmp_path: Path):
         layout = BIDSLayout(tmp_path)
         assert layout.find.features(sub=SUB, kind="phonemic") == []
 
-    def test_run_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK, run="1")
-        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK, run="2")
-        layout = BIDSLayout(layout_tree.root)
+    def test_run_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, task=TASK, run="1")
+        tree.add_feature(kind="phonemic", sub=SUB, task=TASK, run="2")
+        layout = BIDSLayout(tree.root)
         results = layout.find.features(sub=SUB, kind="phonemic", bids_filters=["run-1"])
         assert len(results) == 1
         assert results[0].entities.get("run") == "1"
 
-    def test_cross_session_aggregation_sorted(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_cross_session_aggregation_sorted(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.features(sub=SUB, kind="phonemic")
         assert len(results) == 2
         assert results == sorted(results)
 
-    def test_multiple_ses_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="3", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_multiple_ses_filters(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        tree.add_feature(kind="phonemic", sub=SUB, ses="3", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.features(
             sub=SUB, kind="phonemic", bids_filters=["ses-1", "ses-2"]
         )
@@ -178,83 +178,81 @@ class TestFindFeatures:
 
 
 class TestFindFmriprep:
-    def test_returns_bold_files(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_returns_bold_files(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz")
         assert len(results) == 1
         assert results[0].entities.get("space") == SPACE
         assert results[0].entities.get("desc") == "preproc"
 
-    def test_skips_non_bold_suffix(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
-        layout_tree.add_fmriprep(
-            suffix="mask", ext=".nii.gz", sub=SUB, task=TASK, space=SPACE, desc="brain"
-        )
-        layout = BIDSLayout(layout_tree.root)
+    def test_skips_non_bold_suffix(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK)
+        tree.add_brain_mask(sub=SUB, task=TASK, space=SPACE)
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz")
         assert len(results) == 1
         assert results[0].path.name.endswith("_bold.nii.gz")
 
-    def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="1", task=TASK)
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="2", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_ses_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, ses="1", task=TASK)
+        tree.add_bold(space=SPACE, sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(
             sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["ses-1"]
         )
         assert len(results) == 1
         assert results[0].ses == "1"
 
-    def test_space_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
-        layout_tree.add_fmriprep_bold(space="T1w", sub=SUB, task="rest")
-        layout = BIDSLayout(layout_tree.root)
+    def test_space_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK)
+        tree.add_bold(space="T1w", sub=SUB, task="rest")
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(
             sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=[f"space-{SPACE}"]
         )
         assert len(results) == 1
         assert results[0].entities.get("space") == SPACE
 
-    def test_desc_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, desc="clean", sub=SUB, task=TASK)
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task="rest")
-        layout = BIDSLayout(layout_tree.root)
+    def test_desc_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, desc="clean", sub=SUB, task=TASK)
+        tree.add_bold(space=SPACE, sub=SUB, task="rest")
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(
             sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["desc-clean"]
         )
         assert len(results) == 1
         assert results[0].entities.get("desc") == "clean"
 
-    def test_run_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK, run="1")
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK, run="2")
-        layout = BIDSLayout(layout_tree.root)
+    def test_run_filter_via_bids_filters(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK, run="1")
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK, run="2")
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(
             sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["run-1"]
         )
         assert len(results) == 1
         assert results[0].entities.get("run") == "1"
 
-    def test_rejects_reserved_sub_filter(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_rejects_reserved_sub_filter(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         with pytest.raises(ValueError, match="sub"):
             layout.find.fmriprep(
                 sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["sub-001"]
             )
 
-    def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
-        layout = BIDSLayout(layout_tree.root)
+    def test_returns_empty_when_sub_absent(self, tree: BIDSTree):
+        layout = BIDSLayout(tree.root)
         assert layout.find.fmriprep(sub="999", suffix="bold", ext=".nii.gz") == []
 
     def test_empty_if_fmriprep_absent(self, tmp_path: Path):
         layout = BIDSLayout(tmp_path)
         assert layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz") == []
 
-    def test_cross_session_aggregation_sorted(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="2", task=TASK)
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="1", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_cross_session_aggregation_sorted(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, ses="2", task=TASK)
+        tree.add_bold(space=SPACE, sub=SUB, ses="1", task=TASK)
+        layout = BIDSLayout(tree.root)
         results = layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz")
         assert len(results) == 2
         assert results == sorted(results)
@@ -367,27 +365,27 @@ class TestBuildFeature:
 
 
 class TestListSubjects:
-    def test_subjects_stimuli(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub="002", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_subjects_stimuli(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
+        tree.add_stimulus(kind="audio", ext=".wav", sub="002", task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.subjects(area="stimuli") == [SUB, "002"]
 
-    def test_subjects_features(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_subjects_features(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.subjects(area="features") == [SUB]
 
-    def test_subjects_fmriprep(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_subjects_fmriprep(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.subjects(area="fmriprep") == [SUB]
 
-    def test_subjects_skips_non_sub_dirs(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
-        non_sub_dir = layout_tree.root / "derivatives" / "fmriprep" / "logs"
+    def test_subjects_skips_non_sub_dirs(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK)
+        non_sub_dir = tree.root / "derivatives" / "fmriprep" / "logs"
         non_sub_dir.mkdir(parents=True, exist_ok=True)
-        layout = BIDSLayout(layout_tree.root)
+        layout = BIDSLayout(tree.root)
         assert layout.list.subjects(area="fmriprep") == [SUB]
 
     def test_subjects_empty_if_area_absent(self, tmp_path: Path):
@@ -396,34 +394,34 @@ class TestListSubjects:
 
 
 class TestListSessions:
-    def test_sessions_stimuli(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_sessions_stimuli(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.sessions(sub=SUB, area="stimuli") == ["1", "2"]
 
-    def test_sessions_fmriprep(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses=SES, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_sessions_fmriprep(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, ses=SES, task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.sessions(sub=SUB, area="fmriprep") == [SES]
 
     def test_sessions_empty_if_sub_absent(self, tmp_path: Path):
         layout = BIDSLayout(tmp_path)
         assert layout.list.sessions(sub=SUB, area="stimuli") == []
 
-    def test_sessions_features(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
-        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_sessions_features(self, tree: BIDSTree):
+        tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.sessions(sub=SUB, area="features") == ["1", "2"]
 
-    def test_sessions_skips_non_ses_dirs(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses=SES, task=TASK)
-        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_sessions_skips_non_ses_dirs(self, tree: BIDSTree):
+        tree.add_bold(space=SPACE, sub=SUB, ses=SES, task=TASK)
+        tree.add_bold(space=SPACE, sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.sessions(sub=SUB, area="fmriprep") == [SES]
 
-    def test_sessions_empty_when_subject_has_no_ses(self, layout_tree: HyplineBIDSTree):
-        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
-        layout = BIDSLayout(layout_tree.root)
+    def test_sessions_empty_when_subject_has_no_ses(self, tree: BIDSTree):
+        tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
+        layout = BIDSLayout(tree.root)
         assert layout.list.sessions(sub=SUB, area="stimuli") == []

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -1,0 +1,429 @@
+from pathlib import Path
+
+import pytest
+
+from hypline.bids import BIDSPath
+from hypline.layout import BIDSLayout
+
+from .conftest import HyplineBIDSTree
+
+SUB = "001"
+SES = "1"
+TASK = "conv"
+SPACE = "MNI152NLin6Asym"
+
+
+class TestBIDSLayoutConstruction:
+    def test_raises_if_root_missing(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            BIDSLayout(tmp_path / "nonexistent")
+
+    def test_does_not_raise_if_features_absent(self, tmp_path: Path):
+        (tmp_path / "stimuli").mkdir()
+        BIDSLayout(tmp_path)
+
+
+class TestFindStimuli:
+    def test_returns_matching_files(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(sub=SUB, kind="audio", ext=".wav")
+        assert len(results) == 1
+        assert results[0].sub == SUB
+
+    def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(sub="999", kind="audio", ext=".wav")
+        assert results == []
+
+    def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(
+            sub=SUB, kind="audio", ext=".wav", bids_filters=["ses-1"]
+        )
+        assert len(results) == 1
+        assert results[0].ses == "1"
+
+    def test_arbitrary_bids_filter(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task="conv")
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task="rest")
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(
+            sub=SUB, kind="audio", ext=".wav", bids_filters=["task-conv"]
+        )
+        assert len(results) == 1
+
+    def test_rejects_reserved_sub_filter(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        with pytest.raises(ValueError, match="sub"):
+            layout.find.stimuli(
+                sub=SUB, kind="audio", ext=".wav", bids_filters=["sub-001"]
+            )
+
+    def test_rejects_reserved_stim_filter(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        with pytest.raises(ValueError, match="stim"):
+            layout.find.stimuli(
+                sub=SUB, kind="audio", ext=".wav", bids_filters=["stim-audio"]
+            )
+
+    def test_empty_if_area_absent(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        assert layout.find.stimuli(sub=SUB, kind="audio", ext=".wav") == []
+
+    def test_run_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK, run="1")
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK, run="2")
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(
+            sub=SUB, kind="audio", ext=".wav", bids_filters=["run-1"]
+        )
+        assert len(results) == 1
+        assert results[0].entities.get("run") == "1"
+
+    def test_cross_session_aggregation_sorted(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(sub=SUB, kind="audio", ext=".wav")
+        assert len(results) == 2
+        assert results == sorted(results)
+
+    def test_multiple_ses_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="3", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.stimuli(
+            sub=SUB, kind="audio", ext=".wav", bids_filters=["ses-1", "ses-2"]
+        )
+        assert len(results) == 2
+        assert {r.ses for r in results} == {"1", "2"}
+
+
+class TestFindFeatures:
+    def test_translates_kind_to_feature_entity(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.features(sub=SUB, kind="phonemic")
+        assert len(results) == 1
+        assert results[0].entities.get("feature") == "phonemic"
+
+    def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.features(sub=SUB, kind="phonemic", bids_filters=["ses-1"])
+        assert len(results) == 1
+        assert results[0].ses == "1"
+
+    def test_arbitrary_bids_filter(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK, desc="gpt3")
+        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.features(
+            sub=SUB, kind="phonemic", bids_filters=["desc-gpt3"]
+        )
+        assert len(results) == 1
+        assert results[0].entities.get("desc") == "gpt3"
+
+    def test_rejects_reserved_sub_filter(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        with pytest.raises(ValueError, match="sub"):
+            layout.find.features(sub=SUB, kind="phonemic", bids_filters=["sub-001"])
+
+    def test_rejects_reserved_feature_filter(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        with pytest.raises(ValueError, match="feature"):
+            layout.find.features(
+                sub=SUB, kind="phonemic", bids_filters=["feature-phonemic"]
+            )
+
+    def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.find.features(sub="999", kind="phonemic") == []
+
+    def test_empty_if_area_absent(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        assert layout.find.features(sub=SUB, kind="phonemic") == []
+
+    def test_run_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK, run="1")
+        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK, run="2")
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.features(sub=SUB, kind="phonemic", bids_filters=["run-1"])
+        assert len(results) == 1
+        assert results[0].entities.get("run") == "1"
+
+    def test_cross_session_aggregation_sorted(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.features(sub=SUB, kind="phonemic")
+        assert len(results) == 2
+        assert results == sorted(results)
+
+    def test_multiple_ses_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="3", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.features(
+            sub=SUB, kind="phonemic", bids_filters=["ses-1", "ses-2"]
+        )
+        assert len(results) == 2
+        assert {r.ses for r in results} == {"1", "2"}
+
+
+class TestFindFmriprep:
+    def test_returns_bold_files(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz")
+        assert len(results) == 1
+        assert results[0].entities.get("space") == SPACE
+        assert results[0].entities.get("desc") == "preproc"
+
+    def test_skips_non_bold_suffix(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
+        layout_tree.add_fmriprep(
+            suffix="mask", ext=".nii.gz", sub=SUB, task=TASK, space=SPACE, desc="brain"
+        )
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz")
+        assert len(results) == 1
+        assert results[0].path.name.endswith("_bold.nii.gz")
+
+    def test_ses_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="1", task=TASK)
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(
+            sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["ses-1"]
+        )
+        assert len(results) == 1
+        assert results[0].ses == "1"
+
+    def test_space_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
+        layout_tree.add_fmriprep_bold(space="T1w", sub=SUB, task="rest")
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(
+            sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=[f"space-{SPACE}"]
+        )
+        assert len(results) == 1
+        assert results[0].entities.get("space") == SPACE
+
+    def test_desc_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, desc="clean", sub=SUB, task=TASK)
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task="rest")
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(
+            sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["desc-clean"]
+        )
+        assert len(results) == 1
+        assert results[0].entities.get("desc") == "clean"
+
+    def test_run_filter_via_bids_filters(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK, run="1")
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK, run="2")
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(
+            sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["run-1"]
+        )
+        assert len(results) == 1
+        assert results[0].entities.get("run") == "1"
+
+    def test_rejects_reserved_sub_filter(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        with pytest.raises(ValueError, match="sub"):
+            layout.find.fmriprep(
+                sub=SUB, suffix="bold", ext=".nii.gz", bids_filters=["sub-001"]
+            )
+
+    def test_returns_empty_when_sub_absent(self, layout_tree: HyplineBIDSTree):
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.find.fmriprep(sub="999", suffix="bold", ext=".nii.gz") == []
+
+    def test_empty_if_fmriprep_absent(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        assert layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz") == []
+
+    def test_cross_session_aggregation_sorted(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="2", task=TASK)
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses="1", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        results = layout.find.fmriprep(sub=SUB, suffix="bold", ext=".nii.gz")
+        assert len(results) == 2
+        assert results == sorted(results)
+
+
+class TestBuildStimulus:
+    def test_derives_output_path(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-audio.wav")
+        out = layout.build.stimulus(kind="transcript", source=source, ext=".csv")
+        assert out.entities.get("stim") == "transcript"
+        assert out.path.name.endswith(".csv")
+        assert "stimuli" in out.path.parts
+        assert f"sub-{SUB}" in out.path.parts
+        assert "transcript" in out.path.parts
+
+    def test_applies_entity_override(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-audio.wav")
+        out = layout.build.stimulus(
+            kind="transcript", source=source, ext=".csv", run="02"
+        )
+        assert out.entities.get("run") == "02"
+
+    def test_raises_if_source_missing_sub(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"ses-{SES}_task-{TASK}_stim-audio.wav")
+        with pytest.raises(ValueError, match="sub"):
+            layout.build.stimulus(kind="transcript", source=source, ext=".csv")
+
+    def test_omits_ses_dir_when_source_has_no_ses(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-audio.wav")
+        out = layout.build.stimulus(kind="transcript", source=source, ext=".csv")
+        assert "stimuli" in out.path.parts
+        assert f"sub-{SUB}" in out.path.parts
+        assert not any(p.startswith("ses-") for p in out.path.parts)
+        assert "transcript" in out.path.parts
+
+    def test_includes_ses_dir_when_source_has_ses(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_ses-{SES}_task-{TASK}_stim-audio.wav")
+        out = layout.build.stimulus(kind="transcript", source=source, ext=".csv")
+        assert "stimuli" in out.path.parts
+        assert f"sub-{SUB}" in out.path.parts
+        assert f"ses-{SES}" in out.path.parts
+        assert "transcript" in out.path.parts
+
+    def test_invalid_extension_raises(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-audio.wav")
+        with pytest.raises(ValueError, match="extension"):
+            layout.build.stimulus(kind="transcript", source=source, ext="csv")
+
+    def test_invalid_override_value_raises(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-audio.wav")
+        with pytest.raises(ValueError, match="Invalid BIDS entity"):
+            layout.build.stimulus(
+                kind="transcript", source=source, ext=".csv", run="BAD!"
+            )
+
+
+class TestBuildFeature:
+    def test_derives_output_path(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-transcript.csv")
+        out = layout.build.feature(source=source, kind="phonemic")
+        assert out.entities.get("feature") == "phonemic"
+        assert out.path.suffix == ".parquet"
+        assert "features" in out.path.parts
+        assert f"sub-{SUB}" in out.path.parts
+        assert "phonemic" in out.path.parts
+
+    def test_applies_entity_override(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-transcript.csv")
+        out = layout.build.feature(source=source, kind="phonemic", desc="gpt3")
+        assert out.entities.get("desc") == "gpt3"
+
+    def test_raises_if_source_missing_sub(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"ses-{SES}_task-{TASK}_stim-transcript.csv")
+        with pytest.raises(ValueError, match="sub"):
+            layout.build.feature(source=source, kind="phonemic")
+
+    def test_omits_ses_dir_when_source_has_no_ses(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-transcript.csv")
+        out = layout.build.feature(source=source, kind="phonemic")
+        assert "features" in out.path.parts
+        assert f"sub-{SUB}" in out.path.parts
+        assert not any(p.startswith("ses-") for p in out.path.parts)
+        assert "phonemic" in out.path.parts
+
+    def test_includes_ses_dir_when_source_has_ses(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_ses-{SES}_task-{TASK}_stim-transcript.csv")
+        out = layout.build.feature(source=source, kind="phonemic")
+        assert "features" in out.path.parts
+        assert f"sub-{SUB}" in out.path.parts
+        assert f"ses-{SES}" in out.path.parts
+        assert "phonemic" in out.path.parts
+
+    def test_invalid_override_value_raises(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        source = BIDSPath(f"sub-{SUB}_task-{TASK}_stim-transcript.csv")
+        with pytest.raises(ValueError, match="Invalid BIDS entity"):
+            layout.build.feature(source=source, kind="phonemic", desc="BAD!")
+
+
+class TestListSubjects:
+    def test_subjects_stimuli(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub="002", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.subjects("stimuli") == [SUB, "002"]
+
+    def test_subjects_features(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.subjects("features") == [SUB]
+
+    def test_subjects_fmriprep(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.subjects("fmriprep") == [SUB]
+
+    def test_subjects_skips_non_sub_dirs(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
+        non_sub_dir = layout_tree.root / "derivatives" / "fmriprep" / "logs"
+        non_sub_dir.mkdir(parents=True, exist_ok=True)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.subjects("fmriprep") == [SUB]
+
+    def test_subjects_empty_if_area_absent(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        assert layout.list.subjects("stimuli") == []
+
+
+class TestListSessions:
+    def test_sessions_stimuli(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="1", task=TASK)
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.sessions(sub=SUB, area="stimuli") == ["1", "2"]
+
+    def test_sessions_fmriprep(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses=SES, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.sessions(sub=SUB, area="fmriprep") == [SES]
+
+    def test_sessions_empty_if_sub_absent(self, tmp_path: Path):
+        layout = BIDSLayout(tmp_path)
+        assert layout.list.sessions(sub=SUB, area="stimuli") == []
+
+    def test_sessions_features(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="1", task=TASK)
+        layout_tree.add_feature(kind="phonemic", sub=SUB, ses="2", task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.sessions(sub=SUB, area="features") == ["1", "2"]
+
+    def test_sessions_skips_non_ses_dirs(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, ses=SES, task=TASK)
+        layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.sessions(sub=SUB, area="fmriprep") == [SES]
+
+    def test_sessions_empty_when_subject_has_no_ses(self, layout_tree: HyplineBIDSTree):
+        layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
+        layout = BIDSLayout(layout_tree.root)
+        assert layout.list.sessions(sub=SUB, area="stimuli") == []

--- a/tests/unit/test_layout.py
+++ b/tests/unit/test_layout.py
@@ -371,28 +371,28 @@ class TestListSubjects:
         layout_tree.add_stimulus(kind="audio", ext=".wav", sub=SUB, task=TASK)
         layout_tree.add_stimulus(kind="audio", ext=".wav", sub="002", task=TASK)
         layout = BIDSLayout(layout_tree.root)
-        assert layout.list.subjects("stimuli") == [SUB, "002"]
+        assert layout.list.subjects(area="stimuli") == [SUB, "002"]
 
     def test_subjects_features(self, layout_tree: HyplineBIDSTree):
         layout_tree.add_feature(kind="phonemic", sub=SUB, task=TASK)
         layout = BIDSLayout(layout_tree.root)
-        assert layout.list.subjects("features") == [SUB]
+        assert layout.list.subjects(area="features") == [SUB]
 
     def test_subjects_fmriprep(self, layout_tree: HyplineBIDSTree):
         layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
         layout = BIDSLayout(layout_tree.root)
-        assert layout.list.subjects("fmriprep") == [SUB]
+        assert layout.list.subjects(area="fmriprep") == [SUB]
 
     def test_subjects_skips_non_sub_dirs(self, layout_tree: HyplineBIDSTree):
         layout_tree.add_fmriprep_bold(space=SPACE, sub=SUB, task=TASK)
         non_sub_dir = layout_tree.root / "derivatives" / "fmriprep" / "logs"
         non_sub_dir.mkdir(parents=True, exist_ok=True)
         layout = BIDSLayout(layout_tree.root)
-        assert layout.list.subjects("fmriprep") == [SUB]
+        assert layout.list.subjects(area="fmriprep") == [SUB]
 
     def test_subjects_empty_if_area_absent(self, tmp_path: Path):
         layout = BIDSLayout(tmp_path)
-        assert layout.list.subjects("stimuli") == []
+        assert layout.list.subjects(area="stimuli") == []
 
 
 class TestListSessions:


### PR DESCRIPTION
## Summary

- Add `BIDSLayout` (`src/hypline/layout.py`) as the single authority for path discovery and derivation across `stimuli/`, `features/`, and `derivatives/fmriprep/`.
- Wire `Transcriber`, `PhonemicFeature`, and `Encoding` to take a `BIDSLayout` in place of raw input/output directory arguments.
- Update `transcribe` and `featuregen phonemic` CLIs to a single `bids_root` argument and rename `--bids-filters` to `--data-filters`.
- Rename the `feature` BIDS entity to `feat` across feature I/O and encoding `CellKey` to comply with the 4-character entity convention.
- Extend `BIDSPath` with `__eq__`/`__hash__`/`__lt__` and add `find_bids_files` + `validate_extension` helpers in `hypline.bids`.
- Move `WhisperModel` into `hypline.enums` and lazy-import heavy deps in the CLI to keep `--help` fast.