### PR TITLE
Add cross-subject encoding prediction via Trainer/Predictor split

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -47,6 +47,7 @@ AI agents alike. Agent-agnostic by design.
 | Changing the confound file schema      | `decisions/confound-files.md`                       |
 | Changing the nuisance file schema      | `decisions/nuisance-files.md`                       |
 | Editing encoding / regression logic    | `modules/encoding.md`                               |
+| Predicting out-of-sample / across subjects | `modules/encoding.md`, `decisions/dyad-keyed.md` |
 | Editing denoise / nuisance regression logic | `modules/denoise.md`, `decisions/nuisance-files.md` |
 | Placing a hypline imaging derivative (denoised BOLD) | `decisions/layout.md`, `external/fmriprep.md` |
 | Selecting confound columns (`--columns`/`--custom-columns`) | `modules/denoise.md`, `external/fmriprep.md` |

--- a/notes/decisions/dyad-keyed.md
+++ b/notes/decisions/dyad-keyed.md
@@ -66,14 +66,18 @@ not apply. The same simultaneous-timeline invariant still underwrites it: turn
 windows from the two files share one clock, so cross-file overlap is genuine
 cross-talk (raised) rather than a timeline-misalignment artifact.
 
-## Encoding seam is a stopgap
+## Encoding seam
 
-`Encoding._discover_features` routes `sub → dyad` via `dyad_of` so dyad features
-join to a sub-keyed BOLD model. `CellKey` keeps both `sub` and `dyad` as
-**invariant identities, not cell axes** — dyad features join to sub-keyed BOLD
-without `dyad` becoming a grouping axis. The full cross-subject join (train on
-one partner, predict another) is a separate, larger change and is not yet
-shipped. See [../modules/encoding.md](../modules/encoding.md).
+`_discover_features` (shared by `EncodingTrainer`/`EncodingPredictor`) routes
+`sub → dyad` via `dyad_of` so dyad features join to a sub-keyed BOLD model.
+`CellKey` keeps both `sub` and `dyad` as **invariant identities, not cell axes** —
+dyad features join to sub-keyed BOLD without `dyad` becoming a grouping axis.
+
+The full cross-subject join *is* now shipped: `EncodingPredictor.predict` separates
+the *source*, *model*, and *target* subjects (defined in
+[../modules/encoding.md](../modules/encoding.md#predict--out-of-sample-inference-across-subjects)).
+The dyad-keyed consequence: within one dyad, `source=self`/`partner` give identical X
+because features are dyad-shared, so source varies X only *across* dyads.
 
 See [bidspath-validation.md](bidspath-validation.md) for the `sub` xor `dyad`
 identity rule and `with_identity` re-keying.

--- a/notes/modules/bold.md
+++ b/notes/modules/bold.md
@@ -49,7 +49,10 @@ Because the counts are guaranteed equal, callers producing TR-aligned
 artifacts (e.g. confound files) may anchor `n_trs` on either the raw or the
 preprocessed BOLD — both are correct, and a mismatch can only surface as the
 invariant raising. `n_trs` is also space-invariant across fmriprep outputs of
-the same run, so any `space-*` variant works.
+the same run, so any `space-*` variant works. The count is never re-verified
+against the array at meta-build time; the one divergence that could matter —
+dummy-scan trimming — is refused above, and array-length reconciliation happens
+once, in encoding's `align_y`, on the path that already loads voxels.
 
 For the downstream events-timeline reasoning behind the raw-relative onset
 rule, see [../decisions/feature-files.md](../decisions/feature-files.md).

--- a/notes/modules/encoding.md
+++ b/notes/modules/encoding.md
@@ -1,10 +1,12 @@
 # Encoding — scope and assumptions
 
-What a single encoding training run operates on, what it requires, and
-what assumptions could break it.
+What encoding training and inference operate on, what they require, and
+what assumptions could break them.
 
 The encoding pipeline fits a model from stimulus-derived features (X) to
-BOLD responses (Y) — typically banded ridge regression.
+BOLD responses (Y) — typically banded ridge regression. Training (`EncodingTrainer`)
+and out-of-sample inference (`EncodingPredictor`) are separate roles over a shared
+X-build path; see [Predict](#predict--out-of-sample-inference-across-subjects).
 
 ## Scope of a single training run
 
@@ -12,7 +14,7 @@ A single `train(sub_id)` call is scoped to:
 
 - **One subject.** Subjects are modeled independently — different brains,
   different voxel alignment.
-- **Tasks are an explicit input.** `Encoding(tasks=[...])` declares which
+- **Tasks are an explicit input.** `EncodingTrainer(tasks=[...])` declares which
   task values are in scope; others are excluded at discovery. `task` is a
   `CellKey` axis: `tasks=["A", "B"]` opts into a multi-task fit where
   A-cells and B-cells are distinct rows sharing regression weights.
@@ -20,7 +22,7 @@ A single `train(sub_id)` call is scoped to:
   at the call site.
 - **Multiple sessions and runs: allowed and expected.** More data,
   concatenated into a single X/Y.
-- **Features are named with optional variant.** Each `Encoding(features=[...])`
+- **Features are named with optional variant.** Each `EncodingTrainer(features=[...])`
   entry is `<kind>` (canonical, reads the bare `<kind>/` folder) or
   `<kind>-<desc>` (reads the `<kind>-<desc>/` variant folder). Two entries
   sharing a `kind` are rejected at construction — variants of one kind are
@@ -57,9 +59,51 @@ A single `train(sub_id)` call is scoped to:
    filtered `(dict[FeatureKey, Path], dict[BoldKey, BoldMeta])`.
 5. **`_validate_coverage`** — bidirectional `(ses, task, run)` coverage: every
    filtered BOLD run must have feature coverage and vice versa. Raises if either
-   filtered set is empty. Void-returning.
-6. **`_build_xy`** — loads BOLD arrays; validates `max(slice.stop) ≤ BOLD TRs`;
-   assembles X (features) and Y (BOLD) matrices.
+   filtered set is empty. Void-returning. **Train-only** — predict needs only the
+   feature→BOLD half (already enforced by `_resolve_cell_keys`), so it skips this.
+6. **`_enrich_feature_metas`** — the single feature↔BOLD-timeline crossover: derives
+   each cell's TR-grid placement (`onset_tr`, `n_trs`, `repetition_time`) from
+   `bold_metas` (segment TR-slice, or the run header for unsegmented runs). Reads no
+   BOLD voxel data. Once this runs, X-building never touches `bold_metas` again.
+7. **`_build_x`** — assembles the X feature matrix and its row/column geometry from
+   the enriched metas alone; no Y, no BOLD. Shared by train and predict.
+8. **`_build_training_data`** (train-only) — wraps `_build_x` and appends Y via
+   `_align_y`, which slices each cell's BOLD onto X's row geometry and validates
+   `n_trs` against the array (drift guard + bounds check) before assembling.
+
+## Predict — out-of-sample inference across subjects
+
+Predict reuses the same discovery + `_build_x` path (no parallel builder) so the
+rebuilt X is byte-identical in layout to train's; a `col_slices` mismatch against
+the stored recipe is a hard error (schema-drift guard). It diverges from train in
+three durable ways:
+
+- **Three independent subjects.** *Model* subject = whose trained weights (which
+  artifact). *Source* subject = whose features build X (the prediction inputs).
+  *Target* subject = whose actual BOLD is Y, for comparison (analyze only — predict
+  takes no target). All three are orthogonal; any combination is valid within one
+  study. See [../decisions/dyad-keyed.md](../decisions/dyad-keyed.md).
+- **Cell selection, not coverage.** Each model predicts on its out-of-sample cells
+  by default; an explicit `test_on` selector overrides (honored even for trained-on
+  cells, with a warning, never rejected). OOS is `available − train` for a single
+  model (unbounded — a new subject's extra runs are fair game) but `universe − train`
+  for a K-fold model (bounded to the train corpus). Empty selection is an error,
+  not a silent no-op.
+- **No train-time filters replayed.** Predict discovers the source's *full* cell
+  set; recipe `bids_filters` (the train-corpus bound) are deliberately not re-applied,
+  so `test_on` can name cells outside the original corpus.
+
+The package predicts per-model and never stitches the K predictions — consolidating
+them is the consumer's concern.
+
+## Same-study assumption (load-bearing)
+
+Predict and analyze run across subjects *within one study* sharing the design
+(paradigm, acquisition, TR). Encoding weights tie to a feature space and voxel grid,
+so crossing studies breaks feature alignment regardless of TR. This is a usage
+contract, not a recipe guard: `XRecipe` carries no `repetition_time`, and the
+per-build TR check (`_discover_bold`) plus `_align_y`'s drift guard enforce
+*consistency*, not cross-study tolerance.
 
 ## Alignment contract
 
@@ -148,7 +192,8 @@ before any empty-result `FileNotFoundError`.
 ## Assumptions that could break
 
 - **Consistent TR across all runs** for a subject. Mixed-TR datasets would
-  need per-run TR handling.
+  need per-run TR handling. (Cross-subject predict/analyze additionally assume
+  one shared study — see [Same-study assumption](#same-study-assumption-load-bearing).)
 - **Feature files mirror BOLD identity entities.** See
   [../decisions/feature-files.md](../decisions/feature-files.md).
 - **Segment contract** (single entity, non-overlap, cross-run agreement, cell schema

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -612,87 +612,71 @@ def _reset_cell_lengths(pipeline: "Pipeline", cell_lengths: list[int]) -> None:
                 step.cell_lengths = cell_lengths
 
 
-def _matches(cell: CellKey, test_on: dict[str, str]) -> bool:
-    """Whether `cell` satisfies every entity constraint in `test_on`.
+def _select_cells(
+    available: set[CellKey],
+    artifact: "EncodingArtifact",
+    model: "FittedModel",
+    *,
+    test_on: dict[str, str] | None = None,
+) -> set[CellKey]:
+    """Choose which cells `model` predicts on — out-of-sample by default, or `test_on`.
 
-    Mirrors `_apply_filters._cell_matches`: each `entity -> value` must equal the
-    cell's value for that entity (absent entity never matches). `test_on` is an
-    already-parsed selector; its string grammar is a predict-CLI concern.
+    `available` is the source subject's *full* discovered cell set. Recipe filters
+    are deliberately not replayed: the stored `train`/`universe` sets are trusted,
+    and `test_on` is allowed to name cells outside the train corpus, so narrowing
+    `available` up front would wrongly exclude valid targets.
+
+    The mode (read off the code below) is the easy part; the subtle bits:
+
+    - `test_on` overrides everything and only *warns* on overlap with `train_cells`
+      — predicting on trained-on cells is usually a leak but occasionally deliberate.
+    - K-fold (`universe` set) bounds OOS to the universe so cells the train fold
+      never saw (e.g. a later run discovered only at predict time) aren't selected.
+    - The bounded-OOS presence check exists because K-fold OOS cells come from the
+      *train* subject's universe: one absent on this source would be silently dropped
+      downstream by the feature-subset filter — fewer predictions, no error. Raise.
+
+    Raises on an empty selection.
     """
-    return all(cell.get(entity) == value for entity, value in test_on.items())
-
-
-def _assert_same_cell_schema(
-    available: set[CellKey], train_cells: set[CellKey]
-) -> None:
-    """Raise if source and train cells disagree on their entity key set.
-
-    `available - train_cells` is a set op across (possibly) different subjects;
-    `__eq__`/`__hash__` key on the full entity dict, so a differing schema (source
-    missing `cond`, a different descriptive merge) makes the subtraction silently
-    mis-select. The `col_slices` guard checks *columns*; this checks *cells*. Rests
-    on the "same study => same cell schema" invariant from the overview.
-    """
-    schemas = {c.keys() for c in available} | {c.keys() for c in train_cells}
+    # If source and train cells have different entity keys, they never hash/compare
+    # equal, so `available - train_cells` below subtracts nothing — wrongly keeping
+    # trained-on cells in the OOS set. Catch the mismatch here instead.
+    schemas = {c.keys() for c in available} | {c.keys() for c in model.train_cells}
     if len(schemas) > 1:
         raise ValueError(
             f"Cell-schema mismatch between source and train cells: "
             f"{sorted(sorted(s) for s in schemas)}"
         )
 
-
-def _select_cells(
-    available: set[CellKey],
-    artifact: "EncodingArtifact",
-    model: "FittedModel",
-    test_on: dict[str, str] | None = None,
-) -> set[CellKey]:
-    """Choose which cells `model` predicts on — OOS by default, or `test_on`.
-
-    Runs upstream of `_build_x`, on the source subject's *full* discovered cells
-    (`available`); recipe filters are not replayed — stored `train`/`universe` are
-    trusted. Three modes (model trained on a subset of cells):
-
-    - `test_on`: explicit override, honored regardless of train membership. Warns
-      (does not reject) on overlap with `train_cells` — predicting on trained-on
-      cells is usually a mistake, occasionally intentional. May name cells outside
-      the train corpus.
-    - K-fold (`universe` set): OOS is `universe - train_cells`, bounded by the
-      universe (cells outside it, e.g. a later run, are excluded).
-    - single model (`universe is None`): OOS is `available - train_cells`,
-      unbounded.
-
-    Raises on an empty selection. For the K-fold branch, also raises if the bounded
-    OOS set is not fully present on the source — its cells are drawn from the train
-    subject's `universe`, so a cell absent here would be silently dropped by the
-    feature-subset filter, yielding fewer predictions with no error. Fail fast.
-    """
-    _assert_same_cell_schema(available, model.train_cells)
     if test_on:
-        sel = {c for c in available if _matches(c, test_on)}
-        if sel & model.train_cells:
+        selected = {
+            cell
+            for cell in available
+            if all(cell.get(entity) == value for entity, value in test_on.items())
+        }
+        if selected & model.train_cells:
             logger.warning(
                 "test_on selects {} cell(s) the model was trained on",
-                len(sel & model.train_cells),
+                len(selected & model.train_cells),
             )
     elif artifact.universe is not None:
-        sel = artifact.universe - model.train_cells
+        selected = artifact.universe - model.train_cells
     else:
-        sel = available - model.train_cells
+        selected = available - model.train_cells
 
-    if not sel:
+    if not selected:
         if test_on:
             raise ValueError(f"test_on matched no available cells: {test_on}")
         raise ValueError("empty out-of-sample set — pass test_on to name cells")
 
     if artifact.universe is not None:
-        missing = sel - available
+        missing = selected - available
         if missing:
             raise ValueError(
                 f"bounded OOS cells absent on source subject: "
                 f"{sorted(map(repr, missing))}"
             )
-    return sel
+    return selected
 
 
 def _numpyfy_fitted(obj: object, _seen: set[int] | None = None) -> None:
@@ -1639,7 +1623,7 @@ class EncodingPredictor(_EncodingContext):
 
         results: list[dict] = []
         for model in self._artifact.models:
-            cells = _select_cells(available, self._artifact, model, test_on)
+            cells = _select_cells(available, self._artifact, model, test_on=test_on)
             sub_metas = {
                 feature_key: meta
                 for feature_key, meta in feature_metas.items()

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -155,6 +155,19 @@ class XData:
     row_slices: dict[CellKey, slice]
     col_slices: dict[str, slice]
 
+    def cell_lengths(self, ordered_cells: list[CellKey] | None = None) -> list[int]:
+        """Per-cell row counts — the geometry `CellDelayer` and `_inner_cv` consume.
+
+        Order matters and is positional: these counts must line up with X's row
+        blocks, since `CellDelayer`'s FIR mask keys off cumulative offsets. Pass
+        `ordered_cells` for a cell subset in a specific order (e.g. a fold's train
+        cells); omit it to take all cells in `row_slices` order.
+        """
+        cells = self.row_slices.keys() if ordered_cells is None else ordered_cells
+        return [
+            self.row_slices[cell].stop - self.row_slices[cell].start for cell in cells
+        ]
+
 
 @dataclass(frozen=True)
 class TrainingData(XData):
@@ -589,24 +602,22 @@ def _build_pipeline(
     return Pipeline([("kernelizer", column_kernelizer), ("model", model)])
 
 
-def _reset_cell_lengths(pipeline: "Pipeline", cell_lengths: list[int]) -> None:
+def _rebind_cell_lengths(pipeline: "Pipeline", cell_lengths: list[int]) -> None:
     """Overwrite each band's `CellDelayer.cell_lengths` to the predict geometry.
 
     `CellDelayer` froze the *train* subject's per-cell row counts at fit; its
     `transform` builds FIR boundary masks from them and raises if X's row count
-    disagrees. Predict's cells differ, so the frozen lengths are wrong — reset
+    disagrees. Predict's cells differ, so the frozen lengths are wrong — rebind
     them before predict. Safe because `cell_lengths` only drives boundary masking
     and the row-count check (both functions of the current X), never the fitted
     weights.
 
     Targets `transformers_` — the fitted transformer clones sklearn made at fit
     (the same tree `_numpyfy_fitted` walks) — not the unfitted `.transformers`
-    spec. Each entry is `(name, inner_pipeline, col_slice)`; the inner pipeline's
-    `.steps` are `(step_name, estimator)` tuples. `cell_lengths` order must match
-    X's `row_slices` order.
+    spec, which predict never touches. `cell_lengths` order must match X's
+    `row_slices` order.
     """
-    ck = pipeline.named_steps["kernelizer"]
-    for _, transformer, _ in ck.transformers_:
+    for _, transformer, _ in pipeline.named_steps["kernelizer"].transformers_:
         for _, step in transformer.steps:
             if isinstance(step, CellDelayer):
                 step.cell_lengths = cell_lengths
@@ -1363,10 +1374,7 @@ class EncodingTrainer(_EncodingContext):
             # CellDelayer's boundary masks are built from them at construction.
             # Inner CV is rebuilt per model so its hyperparameter search stays
             # confined to that model's own train cells.
-            cell_lengths = [
-                data.row_slices[cell].stop - data.row_slices[cell].start
-                for cell in ordered_cells
-            ]
+            cell_lengths = data.cell_lengths(ordered_cells)
             cv = _inner_cv(
                 ordered_cells=ordered_cells,
                 cell_lengths=cell_lengths,
@@ -1642,7 +1650,7 @@ class EncodingPredictor(_EncodingContext):
         Consumes pre-discovered, pre-enriched `feature_metas` already subset to the
         selected cells (the analyze loop calls this K times; re-discovering per call
         means K+1 filesystem scans). Rebuilds X via the same `_build_x` path as
-        train, asserts `col_slices` matches the recipe (rebuild guard), resets the
+        train, asserts `col_slices` matches the recipe (rebuild guard), rebinds the
         loaded pipeline's frozen train cell-lengths to this X's geometry, and
         predicts on the numpy backend.
 
@@ -1657,7 +1665,6 @@ class EncodingPredictor(_EncodingContext):
                 f"col_slices drift: {data.col_slices} != {self._recipe.col_slices}"
             )
         set_backend("numpy")
-        cell_lengths = [s.stop - s.start for s in data.row_slices.values()]
-        _reset_cell_lengths(model.pipeline, cell_lengths)
+        _rebind_cell_lengths(model.pipeline, data.cell_lengths())
         Y_hat = model.pipeline.predict(data.X.astype(np.float32))
         return {"row_slices": data.row_slices, "Y_hat": Y_hat}

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -32,7 +32,6 @@ from hypline.events import merge_filename_and_sidecar, segment_tr_slice
 from hypline.io import (
     read_feature,
     read_feature_metadata,
-    skip_existing,
     stack_array_column,
 )
 from hypline.layout import BIDSLayout
@@ -132,7 +131,7 @@ class FeatureMeta:
     """One feature cell's TR-grid placement.
 
     Resolved once by `_enrich_feature_metas` so `_build_x` never reads BOLD.
-    `onset_tr` is currently unconsumed — X rows start at 0 per cell, and `align_y`
+    `onset_tr` is currently unconsumed — X rows start at 0 per cell, and `_align_y`
     recomputes its own onset from the target subject's BOLD.
     """
 
@@ -191,7 +190,7 @@ class XRecipe:
 
 
 @dataclass(frozen=True)
-class EncodingModel:
+class FittedModel:
     """One fitted model and the cell set it was fit on.
 
     `train_cells` is the post-filter `row_slices` key set — the cells actually
@@ -229,7 +228,7 @@ class EncodingArtifact:
 
     recipe: XRecipe
     fold: FoldSpec | None
-    models: list[EncodingModel]
+    models: list[FittedModel]
     universe: set[CellKey] | None
 
 
@@ -425,7 +424,7 @@ def _load_bold_array(path: Path) -> np.ndarray:
         raise ValueError(f"Unsupported image format: {type(img).__name__}")
 
 
-def align_y(
+def _align_y(
     bold_metas: dict[BoldKey, BoldMeta], row_slices: dict[CellKey, slice]
 ) -> np.ndarray:
     """Slice each cell's BOLD response onto X's row geometry.
@@ -638,10 +637,10 @@ def _assert_same_cell_schema(
         )
 
 
-def select_cells(
+def _select_cells(
     available: set[CellKey],
     artifact: "EncodingArtifact",
-    model: "EncodingModel",
+    model: "FittedModel",
     test_on: dict[str, str] | None = None,
 ) -> set[CellKey]:
     """Choose which cells `model` predicts on — OOS by default, or `test_on`.
@@ -734,7 +733,7 @@ def _numpyfy_fitted(obj: object, _seen: set[int] | None = None) -> None:
         setattr(obj, attr, _convert(value))
 
 
-def _write_artifact(artifact: EncodingArtifact, path: Path) -> None:
+def write_artifact(artifact: EncodingArtifact, path: Path) -> None:
     """Dump `artifact` to `path` (.joblib) plus a non-pipeline JSON sidecar.
 
     Forces fitted weights to numpy before the joblib dump (see `_numpyfy_fitted`)
@@ -814,267 +813,41 @@ def load_artifact(path: Path) -> EncodingArtifact:
     return joblib.load(path)
 
 
-class Encoding:
-    def __init__(
-        self,
-        config: EncodingConfig,
-        *,
-        bids_root: str | Path,
-        features: list[str],
-        tasks: list[str],
-        bold_space: str,
-        bold_desc: str = "denoised",
-        downsample: FeatureDownsampleMethod = "mean",
-        bids_filters: list[str] | None = None,
-        fold_by: str | None = None,
-        n_folds: int | Literal["loo"] | None = None,
-        desc: str,
-        force: bool = False,
-    ):
-        import torch
+class _EncodingContext:
+    """Shared recipe-derived discovery/build path for train and predict.
 
-        if config.device is Device.CUDA and not torch.cuda.is_available():
-            raise RuntimeError("CUDA is requested but not available")
-        self.config = config
-        self._layout = BIDSLayout(bids_root)
+    Not instantiated directly. Both `EncodingTrainer` and `EncodingPredictor`
+    inherit these methods; they differ only in how the recipe attrs are
+    populated (validated constructor args vs. a loaded artifact).
+    """
 
-        if not features:
-            raise ValueError("features must be a non-empty list")
-        parsed = [parse_kind_desc(entry) for entry in features]
-        kinds = [kind for kind, _ in parsed]
-        if len(kinds) != len(set(kinds)):
-            dupes = sorted({k for k in kinds if kinds.count(k) > 1})
-            raise ValueError(
-                f"Duplicate feature kind(s) {dupes} in features"
-                " — each kind may appear once"
-            )
-        # Iteration order fixes X column layout
-        self._features: dict[str, tuple[str, str | None]] = dict(zip(features, parsed))
+    # Attribute contract: subclasses set these (trainer in __init__, predictor via
+    # _set_recipe_attrs). Declared here so the shared methods type-check against the
+    # base. `_layout` is caller-supplied (bids_root); the rest are recipe-derived.
+    _layout: BIDSLayout
+    _features: dict[str, tuple[str, str | None]]
+    tasks: list[str]
+    _task_filters: list[str]
+    bold_space: SurfaceSpace | VolumeSpace
+    _bold_desc: str
+    downsample: FeatureDownsampleMethod
+    _recipe: XRecipe
 
-        if not tasks:
-            raise ValueError("tasks must be a non-empty list")
-        if len(tasks) != len(set(tasks)):
-            dupes = sorted({t for t in tasks if tasks.count(t) > 1})
-            raise ValueError(f"Duplicate entries in tasks: {dupes}")
-        self.tasks = tasks
-        self._task_filters = [f"task-{task}" for task in tasks]
+    def _set_recipe_attrs(self, recipe: XRecipe) -> None:
+        """Populate the recipe-derived attrs both roles share.
 
-        self.bold_space = parse_bold_space(bold_space)
-
-        if not BIDS_ENTITY_VALUE_RE.match(bold_desc):
-            raise ValueError(f"Invalid bold_desc: {bold_desc!r}")
-        self._bold_desc = bold_desc
-
-        if downsample not in get_args(FeatureDownsampleMethod):
-            raise ValueError(
-                f"downsample must be one of {get_args(FeatureDownsampleMethod)};"
-                f" got {downsample!r}"
-            )
-        self.downsample = downsample
-
-        self.bids_filters = normalize_bids_filters(
-            bids_filters, reserved={"sub", "task", "space", "feat", "desc"}
-        )
-
-        # fold_by/n_folds are paired: both define one fold group or neither does.
-        # Only subject-independent checks run here; group-count and entity-presence
-        # validation is data-dependent and deferred to train / _partition_groups.
-        if (fold_by is None) != (n_folds is None):
-            raise ValueError(
-                "fold_by and n_folds must be set together or both left unset; "
-                f"got fold_by={fold_by!r}, n_folds={n_folds!r}"
-            )
-        self._fold: FoldSpec | None = None
-        if fold_by is not None:
-            assert n_folds is not None
-            if fold_by in CellKey.EXCLUDE:
-                raise ValueError(
-                    f"fold_by={fold_by!r} is not a cell axis (it never appears on "
-                    f"a cell); valid axes exclude {sorted(CellKey.EXCLUDE)}"
-                )
-            if n_folds != "loo" and n_folds < 2:
-                raise ValueError(
-                    f"n_folds must be >= 2 or 'loo'; got {n_folds!r}. A single fold "
-                    "is no split — pass n_folds=None for a single model"
-                )
-            self._fold = FoldSpec(by=fold_by, n=n_folds)
-
-        if not BIDS_ENTITY_VALUE_RE.match(desc):
-            raise ValueError(f"Invalid desc: {desc!r}")
-        self._desc = desc
-        self._force = force
-
-        # col_slices is filled by train from the assembled TrainingData
-        self._recipe = XRecipe(
-            features=self._features,
-            tasks=self.tasks,
-            bold_space=self.bold_space,
-            bold_desc=self._bold_desc,
-            downsample=self.downsample,
-            bids_filters=self.bids_filters,
-            delays=self.config.delays,
-            alphas=self.config.alphas,
-        )
-
-    def train(self, sub_id: str) -> EncodingArtifact:
-        """Fit the encoding model for a subject and persist it as an artifact.
-
-        Writes a `.joblib` blob plus a JSON sidecar to the `desc`-keyed results
-        path and returns the in-memory `EncodingArtifact`. An existing file is
-        left untouched and loaded back unless `force=True` — the fit is skipped
-        entirely, mirroring featuregen/confoundgen's check-before-compute.
+        These attrs drive the discovery/build path (`_discover_*`, `_build_x`).
+        The trainer fills them inline during validated `__init__`; the predictor
+        calls this from a loaded `artifact.recipe`. `_layout`/`_artifact` are set
+        by the caller — they are not recipe-derived (`bids_root` is a caller arg).
         """
-        out = self._layout.path.result(sub=sub_id, kind="encoding", desc=self._desc)
-        if skip_existing(out.path, force=self._force):
-            return load_artifact(out.path)
-
-        feature_bids = self._discover_features(sub_id)
-        bold_metas = self._discover_bold(sub_id)
-        feature_bids = self._resolve_cell_keys(sub_id, feature_bids, bold_metas)
-        feature_bids, bold_metas = self._apply_filters(sub_id, feature_bids, bold_metas)
-        self._validate_coverage(sub_id, feature_bids, bold_metas)
-        feature_metas = self._enrich_feature_metas(feature_bids, bold_metas)
-        data = self._build_training_data(feature_metas, bold_metas)
-
-        # himalaya binds the backend at estimator construction, not at fit — set it
-        # before building the pipeline or fitting silently falls back to CPU
-        from himalaya.backend import set_backend
-
-        set_backend("torch_cuda" if self.config.device is Device.CUDA else "torch")
-
-        # segment entity is invariant across bold_metas (validated in _discover_bold);
-        # None when runs are unsegmented
-        segment_metas = [meta for meta in (bold_metas or {}).values() if meta.segments]
-        segment_entity = segment_metas[0].segments[0].entity if segment_metas else None
-
-        def _fit_model(
-            X: np.ndarray,
-            Y: np.ndarray,
-            ordered_cells: list[CellKey],
-        ):
-            # Each fold needs a fresh pipeline: cell_lengths differ per fold and
-            # CellDelayer's boundary masks are built from them at construction.
-            # Inner CV is rebuilt per model so its hyperparameter search stays
-            # confined to that model's own train cells.
-            cell_lengths = [
-                data.row_slices[cell].stop - data.row_slices[cell].start
-                for cell in ordered_cells
-            ]
-            cv = _inner_cv(
-                ordered_cells=ordered_cells,
-                cell_lengths=cell_lengths,
-                segment_entity=segment_entity,
-                fold=self._fold,
-            )
-            pipeline = _build_pipeline(
-                col_slices=data.col_slices,
-                cell_lengths=cell_lengths,
-                delays=self.config.delays,
-                alphas=self.config.alphas,
-                cv=cv,
-            )
-            # torch backends want float32; float64 doubles memory and can error on CUDA
-            pipeline.fit(X.astype(np.float32), Y.astype(np.float32))
-            return pipeline
-
-        recipe = replace(self._recipe, col_slices=data.col_slices)
-
-        if self._fold is None:
-            # cell order tracks data.row_slices (= _build_x / _sort_key order)
-            ordered_cells = list(data.row_slices)
-            pipeline = _fit_model(data.X, data.Y, ordered_cells)
-            artifact = EncodingArtifact(
-                recipe=recipe,
-                fold=None,
-                models=[
-                    EncodingModel(pipeline=pipeline, train_cells=set(data.row_slices))
-                ],
-                universe=None,
-            )
-        else:
-            all_cells = set(data.row_slices)
-            groups = _group_cells_by(all_cells, self._fold.by)
-            held_out = _partition_groups(groups, self._fold.n)
-            models = []
-            for held in held_out:
-                train_cells = all_cells - held
-                X_sub, Y_sub, ordered_cells = _select_rows(data, train_cells)
-                pipeline = _fit_model(X_sub, Y_sub, ordered_cells)
-                models.append(EncodingModel(pipeline=pipeline, train_cells=train_cells))
-            artifact = EncodingArtifact(
-                recipe=recipe, fold=self._fold, models=models, universe=all_cells
-            )
-
-        _write_artifact(artifact, out.path)
-        return artifact
-
-    @classmethod
-    def load(cls, bids_root: str | Path, *, sub: str, desc: str) -> EncodingArtifact:
-        """Load a persisted encoding artifact, resolving it from `(sub, desc)`.
-
-        `(sub, kind="encoding", desc)` fully determines the file, so no
-        `Encoding` instance or recipe is needed to read one back.
-        """
-        layout = BIDSLayout(bids_root)
-        out = layout.path.result(sub=sub, kind="encoding", desc=desc)
-        return load_artifact(out.path)
-
-    @classmethod
-    def _from_recipe(cls, recipe: XRecipe, bids_root: str | Path) -> "Encoding":
-        """Rebuild an `Encoding` from a stored recipe to drive predict.
-
-        Predict has no constructor args and runs on a possibly different subject
-        in a different `bids_root`, but discovery/build are instance methods
-        reading `self._features`, `self.bold_space`, etc. Reconstruct exactly those
-        attributes from the recipe. `__new__` bypasses `__init__` validation —
-        recipe values were validated at train, and re-running validation would
-        require dummy `desc`/`fold`/`force` args for no gain.
-
-        No `config`/`device`: predict runs on the numpy backend (CPU always), and
-        the discovery/build path predict uses reads no `self.config`. `bids_root`
-        is a caller argument, deliberately not part of X identity. The loaded
-        recipe carries `col_slices` (train-filled) for the rebuild assert.
-        """
-        enc = cls.__new__(cls)
-        enc._layout = BIDSLayout(bids_root)
-        enc._features = recipe.features
-        enc.tasks = recipe.tasks
-        enc._task_filters = [f"task-{task}" for task in recipe.tasks]
-        enc.bold_space = recipe.bold_space
-        enc._bold_desc = recipe.bold_desc
-        enc.downsample = recipe.downsample
-        enc._recipe = recipe
-        return enc
-
-    def _predict_model(
-        self,
-        model: EncodingModel,
-        feature_metas: dict[FeatureKey, FeatureMeta],
-    ) -> dict:
-        """Run one model over a pre-selected cell set, returning its `Y_hat` (no Y).
-
-        Consumes pre-discovered, pre-enriched `feature_metas` already subset to the
-        selected cells (the analyze loop calls this K times; re-discovering per call
-        means K+1 filesystem scans). Rebuilds X via the same `_build_x` path as
-        train, asserts `col_slices` matches the recipe (rebuild guard), resets the
-        loaded pipeline's frozen train cell-lengths to this X's geometry, and
-        predicts on the numpy backend.
-
-        Returns `{"row_slices": ..., "Y_hat": ...}` — per-model, no actual Y. The
-        caller does `align_y(target_bold, row_slices)` if it wants Y to compare against.
-        """
-        from himalaya.backend import set_backend
-
-        data = self._build_x(feature_metas)
-        if data.col_slices != self._recipe.col_slices:
-            raise ValueError(
-                f"col_slices drift: {data.col_slices} != {self._recipe.col_slices}"
-            )
-        set_backend("numpy")
-        cell_lengths = [s.stop - s.start for s in data.row_slices.values()]
-        _reset_cell_lengths(model.pipeline, cell_lengths)
-        Y_hat = model.pipeline.predict(data.X.astype(np.float32))
-        return {"row_slices": data.row_slices, "Y_hat": Y_hat}
+        self._features = recipe.features
+        self.tasks = recipe.tasks
+        self._task_filters = [f"task-{task}" for task in recipe.tasks]
+        self.bold_space = recipe.bold_space
+        self._bold_desc = recipe.bold_desc
+        self.downsample = recipe.downsample
+        self._recipe = recipe
 
     def _discover_features(self, sub_id: str) -> dict[FeatureKey, BIDSPath]:
         """Discover and validate feature file paths for a subject.
@@ -1363,6 +1136,315 @@ class Encoding:
 
         return resolved_feature_bids
 
+    def _enrich_feature_metas(
+        self,
+        feature_bids: dict[FeatureKey, BIDSPath],
+        bold_metas: dict[BoldKey, BoldMeta],
+    ) -> dict[FeatureKey, FeatureMeta]:
+        """Enrich each feature path into a `FeatureMeta` with its TR-grid placement.
+
+        The crossover between feature cells and the BOLD timeline happens here,
+        once: derive `(onset_tr, n_trs)` from the segment TR-slice for segmented
+        runs, or from the run's header `n_trs` for unsegmented runs, and stamp
+        `repetition_time`. `_build_x` then reads placement off the metas and never
+        touches `bold_metas`.
+
+        No BOLD voxel data is read — placement comes from `bold_metas` alone.
+        The header `n_trs` carried by each meta is trusted; `_align_y` reconciles
+        it against the actual array.
+        """
+        cells_by_bold_key: dict[BoldKey, set[CellKey]] = {}
+        for feature_key in feature_bids:
+            bold_key = feature_key.cell.to_bold_key()
+            cells_by_bold_key.setdefault(bold_key, set()).add(feature_key.cell)
+
+        placement_by_cell: dict[CellKey, tuple[int, int, float]] = {}
+        for bold_key, cells in cells_by_bold_key.items():
+            bold_meta = bold_metas[bold_key]
+            if not bold_meta.segments:
+                # Unsegmented: the whole run is one cell spanning the full timeline
+                for cell_key in cells:
+                    placement_by_cell[cell_key] = (
+                        0,
+                        bold_meta.n_trs,
+                        bold_meta.repetition_time,
+                    )
+            else:
+                for cell_key in cells:
+                    segment = next(
+                        seg
+                        for seg in bold_meta.segments
+                        if seg.value == cell_key[seg.entity]
+                    )
+                    tr_slice = segment_tr_slice(segment, bold_meta.repetition_time)
+                    placement_by_cell[cell_key] = (
+                        tr_slice.start,  # onset_tr
+                        tr_slice.stop - tr_slice.start,  # n_trs
+                        bold_meta.repetition_time,
+                    )
+
+        feature_metas: dict[FeatureKey, FeatureMeta] = {}
+        for feature_key, bids in feature_bids.items():
+            onset_tr, n_trs, repetition_time = placement_by_cell[feature_key.cell]
+            feature_metas[feature_key] = FeatureMeta(
+                bids=bids,
+                n_trs=n_trs,
+                onset_tr=onset_tr,
+                repetition_time=repetition_time,
+            )
+        return feature_metas
+
+    def _build_x(self, feature_metas: dict[FeatureKey, FeatureMeta]) -> XData:
+        """Assemble the X feature matrix and its row/column geometry, no target.
+
+        Reads `n_trs`/`repetition_time` off each cell's `FeatureMeta` — the
+        crossover with the BOLD timeline already happened in `_enrich_feature_metas`,
+        so X no longer touches `bold_metas` and no BOLD data enters X.
+
+        Cells are sorted deterministically so row positions are stable across
+        runs. Column layout is derived from the first cell and assumed invariant —
+        all cells must yield the same feature dimensionality.
+        """
+
+        # None sorts before any value; empty string is a stable tiebreaker for ses/run
+        def _sort_key(k: CellKey) -> tuple:
+            ses = k.get("ses")
+            task = k["task"]
+            run = k.get("run")
+            rest = sorted(
+                val for key, val in k.items() if key not in ("ses", "run", "task")
+            )
+            return (ses is not None, ses or "", task, run is not None, run or "", *rest)
+
+        cell_keys = sorted(
+            {feature_key.cell for feature_key in feature_metas}, key=_sort_key
+        )
+
+        X_parts: list[np.ndarray] = []
+        row_slices: dict[CellKey, slice] = {}
+        col_slices: dict[str, slice] = {}
+        row_offset = 0
+        col_offset = 0
+        col_slices_initialized = False
+
+        for cell_key in cell_keys:
+            # Geometry is per-cell, shared across this cell's feature metas
+            cell_meta = feature_metas[FeatureKey(cell_key, next(iter(self._features)))]
+            n_trs = cell_meta.n_trs
+            row_slices[cell_key] = slice(row_offset, row_offset + n_trs)
+            row_offset += n_trs
+
+            # Construct X for the given cell
+            feature_arrays: list[np.ndarray] = []
+            for feature_name in self._features:
+                meta = feature_metas[FeatureKey(cell_key, feature_name)]
+                df = read_feature(meta.bids.path)
+                # Drop untimed rows — downsample needs TR alignment
+                df = df.filter(df.get_column("start_time").is_not_null())
+                arr = downsample(
+                    stack_array_column(df.get_column("feature")),
+                    start_times=df.get_column("start_time").to_numpy(),
+                    n_trs=n_trs,
+                    repetition_time=meta.repetition_time,
+                    method=self.downsample,
+                )
+                feature_arrays.append(arr)
+            if not col_slices_initialized:
+                for feature_name, arr in zip(self._features, feature_arrays):
+                    n_cols = arr.shape[1]
+                    col_slices[feature_name] = slice(col_offset, col_offset + n_cols)
+                    col_offset += n_cols
+                col_slices_initialized = True  # col slices are invariant across cells
+            X_parts.append(np.hstack(feature_arrays))
+
+        X = np.concatenate(X_parts, axis=0)
+        return XData(X=X, row_slices=row_slices, col_slices=col_slices)
+
+
+class EncodingTrainer(_EncodingContext):
+    """Recipe -> fit -> artifact. Owns validation, filtering, and Y-build."""
+
+    def __init__(
+        self,
+        config: EncodingConfig,
+        *,
+        bids_root: str | Path,
+        features: list[str],
+        tasks: list[str],
+        bold_space: str,
+        bold_desc: str = "denoised",
+        downsample: FeatureDownsampleMethod = "mean",
+        bids_filters: list[str] | None = None,
+        fold_by: str | None = None,
+        n_folds: int | Literal["loo"] | None = None,
+    ):
+        import torch
+
+        if config.device is Device.CUDA and not torch.cuda.is_available():
+            raise RuntimeError("CUDA is requested but not available")
+        self.config = config
+        self._layout = BIDSLayout(bids_root)
+
+        if not features:
+            raise ValueError("features must be a non-empty list")
+        parsed = [parse_kind_desc(entry) for entry in features]
+        kinds = [kind for kind, _ in parsed]
+        if len(kinds) != len(set(kinds)):
+            dupes = sorted({k for k in kinds if kinds.count(k) > 1})
+            raise ValueError(
+                f"Duplicate feature kind(s) {dupes} in features"
+                " — each kind may appear once"
+            )
+        # Iteration order fixes X column layout
+        self._features: dict[str, tuple[str, str | None]] = dict(zip(features, parsed))
+
+        if not tasks:
+            raise ValueError("tasks must be a non-empty list")
+        if len(tasks) != len(set(tasks)):
+            dupes = sorted({t for t in tasks if tasks.count(t) > 1})
+            raise ValueError(f"Duplicate entries in tasks: {dupes}")
+        self.tasks = tasks
+        self._task_filters = [f"task-{task}" for task in tasks]
+
+        self.bold_space = parse_bold_space(bold_space)
+
+        if not BIDS_ENTITY_VALUE_RE.match(bold_desc):
+            raise ValueError(f"Invalid bold_desc: {bold_desc!r}")
+        self._bold_desc = bold_desc
+
+        if downsample not in get_args(FeatureDownsampleMethod):
+            raise ValueError(
+                f"downsample must be one of {get_args(FeatureDownsampleMethod)};"
+                f" got {downsample!r}"
+            )
+        self.downsample = downsample
+
+        self.bids_filters = normalize_bids_filters(
+            bids_filters, reserved={"sub", "task", "space", "feat", "desc"}
+        )
+
+        # fold_by/n_folds are paired: both define one fold group or neither does.
+        # Only subject-independent checks run here; group-count and entity-presence
+        # validation is data-dependent and deferred to train / _partition_groups.
+        if (fold_by is None) != (n_folds is None):
+            raise ValueError(
+                "fold_by and n_folds must be set together or both left unset; "
+                f"got fold_by={fold_by!r}, n_folds={n_folds!r}"
+            )
+        self._fold: FoldSpec | None = None
+        if fold_by is not None:
+            assert n_folds is not None
+            if fold_by in CellKey.EXCLUDE:
+                raise ValueError(
+                    f"fold_by={fold_by!r} is not a cell axis (it never appears on "
+                    f"a cell); valid axes exclude {sorted(CellKey.EXCLUDE)}"
+                )
+            if n_folds != "loo" and n_folds < 2:
+                raise ValueError(
+                    f"n_folds must be >= 2 or 'loo'; got {n_folds!r}. A single fold "
+                    "is no split — pass n_folds=None for a single model"
+                )
+            self._fold = FoldSpec(by=fold_by, n=n_folds)
+
+        # col_slices is filled by train from the assembled TrainingData
+        self._recipe = XRecipe(
+            features=self._features,
+            tasks=self.tasks,
+            bold_space=self.bold_space,
+            bold_desc=self._bold_desc,
+            downsample=self.downsample,
+            bids_filters=self.bids_filters,
+            delays=self.config.delays,
+            alphas=self.config.alphas,
+        )
+
+    def train(self, sub_id: str) -> EncodingArtifact:
+        """Fit the encoding model for a subject and return the in-memory artifact.
+
+        Pure compute: discovers, builds X/Y, fits, and returns the
+        `EncodingArtifact`. Persistence is the caller's concern — pass the result
+        to `write_artifact` to store it, and gate the fit on `skip_existing`
+        before calling if a check-before-compute cache is wanted.
+        """
+        feature_bids = self._discover_features(sub_id)
+        bold_metas = self._discover_bold(sub_id)
+        feature_bids = self._resolve_cell_keys(sub_id, feature_bids, bold_metas)
+        feature_bids, bold_metas = self._apply_filters(sub_id, feature_bids, bold_metas)
+        self._validate_coverage(sub_id, feature_bids, bold_metas)
+        feature_metas = self._enrich_feature_metas(feature_bids, bold_metas)
+        data = self._build_training_data(feature_metas, bold_metas)
+
+        # himalaya binds the backend at estimator construction, not at fit — set it
+        # before building the pipeline or fitting silently falls back to CPU
+        from himalaya.backend import set_backend
+
+        set_backend("torch_cuda" if self.config.device is Device.CUDA else "torch")
+
+        # segment entity is invariant across bold_metas (validated in _discover_bold);
+        # None when runs are unsegmented
+        segment_metas = [meta for meta in (bold_metas or {}).values() if meta.segments]
+        segment_entity = segment_metas[0].segments[0].entity if segment_metas else None
+
+        def _fit_model(
+            X: np.ndarray,
+            Y: np.ndarray,
+            ordered_cells: list[CellKey],
+        ):
+            # Each fold needs a fresh pipeline: cell_lengths differ per fold and
+            # CellDelayer's boundary masks are built from them at construction.
+            # Inner CV is rebuilt per model so its hyperparameter search stays
+            # confined to that model's own train cells.
+            cell_lengths = [
+                data.row_slices[cell].stop - data.row_slices[cell].start
+                for cell in ordered_cells
+            ]
+            cv = _inner_cv(
+                ordered_cells=ordered_cells,
+                cell_lengths=cell_lengths,
+                segment_entity=segment_entity,
+                fold=self._fold,
+            )
+            pipeline = _build_pipeline(
+                col_slices=data.col_slices,
+                cell_lengths=cell_lengths,
+                delays=self.config.delays,
+                alphas=self.config.alphas,
+                cv=cv,
+            )
+            # torch backends want float32; float64 doubles memory and can error on CUDA
+            pipeline.fit(X.astype(np.float32), Y.astype(np.float32))
+            return pipeline
+
+        recipe = replace(self._recipe, col_slices=data.col_slices)
+
+        if self._fold is None:
+            # cell order tracks data.row_slices (= _build_x / _sort_key order)
+            ordered_cells = list(data.row_slices)
+            pipeline = _fit_model(data.X, data.Y, ordered_cells)
+            artifact = EncodingArtifact(
+                recipe=recipe,
+                fold=None,
+                models=[
+                    FittedModel(pipeline=pipeline, train_cells=set(data.row_slices))
+                ],
+                universe=None,
+            )
+        else:
+            all_cells = set(data.row_slices)
+            groups = _group_cells_by(all_cells, self._fold.by)
+            held_out = _partition_groups(groups, self._fold.n)
+            models = []
+            for held in held_out:
+                train_cells = all_cells - held
+                X_sub, Y_sub, ordered_cells = _select_rows(data, train_cells)
+                pipeline = _fit_model(X_sub, Y_sub, ordered_cells)
+                models.append(FittedModel(pipeline=pipeline, train_cells=train_cells))
+            artifact = EncodingArtifact(
+                recipe=recipe, fold=self._fold, models=models, universe=all_cells
+            )
+
+        return artifact
+
     def _apply_filters(
         self,
         sub_id: str,
@@ -1478,130 +1560,6 @@ class Encoding:
                 msg += f" ({len(features_without_bold) - 1} other coverage gaps exist)"
             raise FileNotFoundError(msg)
 
-    def _enrich_feature_metas(
-        self,
-        feature_bids: dict[FeatureKey, BIDSPath],
-        bold_metas: dict[BoldKey, BoldMeta],
-    ) -> dict[FeatureKey, FeatureMeta]:
-        """Enrich each feature path into a `FeatureMeta` with its TR-grid placement.
-
-        The crossover between feature cells and the BOLD timeline happens here,
-        once: derive `(onset_tr, n_trs)` from the segment TR-slice for segmented
-        runs, or from the run's header `n_trs` for unsegmented runs, and stamp
-        `repetition_time`. `_build_x` then reads placement off the metas and never
-        touches `bold_metas`.
-
-        No BOLD voxel data is read — placement comes from `bold_metas` alone.
-        The header `n_trs` carried by each meta is trusted; `align_y` reconciles
-        it against the actual array.
-        """
-        cells_by_bold_key: dict[BoldKey, set[CellKey]] = {}
-        for feature_key in feature_bids:
-            bold_key = feature_key.cell.to_bold_key()
-            cells_by_bold_key.setdefault(bold_key, set()).add(feature_key.cell)
-
-        placement_by_cell: dict[CellKey, tuple[int, int, float]] = {}
-        for bold_key, cells in cells_by_bold_key.items():
-            bold_meta = bold_metas[bold_key]
-            if not bold_meta.segments:
-                # Unsegmented: the whole run is one cell spanning the full timeline
-                for cell_key in cells:
-                    placement_by_cell[cell_key] = (
-                        0,
-                        bold_meta.n_trs,
-                        bold_meta.repetition_time,
-                    )
-            else:
-                for cell_key in cells:
-                    segment = next(
-                        seg
-                        for seg in bold_meta.segments
-                        if seg.value == cell_key[seg.entity]
-                    )
-                    tr_slice = segment_tr_slice(segment, bold_meta.repetition_time)
-                    placement_by_cell[cell_key] = (
-                        tr_slice.start,  # onset_tr
-                        tr_slice.stop - tr_slice.start,  # n_trs
-                        bold_meta.repetition_time,
-                    )
-
-        feature_metas: dict[FeatureKey, FeatureMeta] = {}
-        for feature_key, bids in feature_bids.items():
-            onset_tr, n_trs, repetition_time = placement_by_cell[feature_key.cell]
-            feature_metas[feature_key] = FeatureMeta(
-                bids=bids,
-                n_trs=n_trs,
-                onset_tr=onset_tr,
-                repetition_time=repetition_time,
-            )
-        return feature_metas
-
-    def _build_x(self, feature_metas: dict[FeatureKey, FeatureMeta]) -> XData:
-        """Assemble the X feature matrix and its row/column geometry, no target.
-
-        Reads `n_trs`/`repetition_time` off each cell's `FeatureMeta` — the
-        crossover with the BOLD timeline already happened in `_enrich_feature_metas`,
-        so X no longer touches `bold_metas` and no BOLD data enters X.
-
-        Cells are sorted deterministically so row positions are stable across
-        runs. Column layout is derived from the first cell and assumed invariant —
-        all cells must yield the same feature dimensionality.
-        """
-
-        # None sorts before any value; empty string is a stable tiebreaker for ses/run
-        def _sort_key(k: CellKey) -> tuple:
-            ses = k.get("ses")
-            task = k["task"]
-            run = k.get("run")
-            rest = sorted(
-                val for key, val in k.items() if key not in ("ses", "run", "task")
-            )
-            return (ses is not None, ses or "", task, run is not None, run or "", *rest)
-
-        cell_keys = sorted(
-            {feature_key.cell for feature_key in feature_metas}, key=_sort_key
-        )
-
-        X_parts: list[np.ndarray] = []
-        row_slices: dict[CellKey, slice] = {}
-        col_slices: dict[str, slice] = {}
-        row_offset = 0
-        col_offset = 0
-        col_slices_initialized = False
-
-        for cell_key in cell_keys:
-            # Geometry is per-cell, shared across this cell's feature metas
-            cell_meta = feature_metas[FeatureKey(cell_key, next(iter(self._features)))]
-            n_trs = cell_meta.n_trs
-            row_slices[cell_key] = slice(row_offset, row_offset + n_trs)
-            row_offset += n_trs
-
-            # Construct X for the given cell
-            feature_arrays: list[np.ndarray] = []
-            for feature_name in self._features:
-                meta = feature_metas[FeatureKey(cell_key, feature_name)]
-                df = read_feature(meta.bids.path)
-                # Drop untimed rows — downsample needs TR alignment
-                df = df.filter(df.get_column("start_time").is_not_null())
-                arr = downsample(
-                    stack_array_column(df.get_column("feature")),
-                    start_times=df.get_column("start_time").to_numpy(),
-                    n_trs=n_trs,
-                    repetition_time=meta.repetition_time,
-                    method=self.downsample,
-                )
-                feature_arrays.append(arr)
-            if not col_slices_initialized:
-                for feature_name, arr in zip(self._features, feature_arrays):
-                    n_cols = arr.shape[1]
-                    col_slices[feature_name] = slice(col_offset, col_offset + n_cols)
-                    col_offset += n_cols
-                col_slices_initialized = True  # col slices are invariant across cells
-            X_parts.append(np.hstack(feature_arrays))
-
-        X = np.concatenate(X_parts, axis=0)
-        return XData(X=X, row_slices=row_slices, col_slices=col_slices)
-
     def _build_training_data(
         self,
         feature_metas: dict[FeatureKey, FeatureMeta],
@@ -1611,13 +1569,125 @@ class Encoding:
 
         The X+Y carrier is train-only — predict stops at X (`_build_x`) and never
         builds Y. Segment coverage vs. actual BOLD array length is checked in
-        `align_y`; a mismatch raises rather than producing a silently truncated Y.
+        `_align_y`; a mismatch raises rather than producing a silently truncated Y.
         """
         x_data = self._build_x(feature_metas)
-        Y = align_y(bold_metas, x_data.row_slices)
+        Y = _align_y(bold_metas, x_data.row_slices)
         return TrainingData(
             X=x_data.X,
             row_slices=x_data.row_slices,
             col_slices=x_data.col_slices,
             Y=Y,
         )
+
+
+class EncodingPredictor(_EncodingContext):
+    """Loaded artifact -> inference. Rebuilds X via the shared path."""
+
+    def __init__(self, *, bids_root: str | Path, artifact: EncodingArtifact) -> None:
+        """Wrap a loaded artifact to drive predict on a given `bids_root`.
+
+        Reconstructs the discovery/build attrs from `artifact.recipe` (validated
+        at train, so no re-validation here) and stashes the whole `artifact`: the
+        `predict` loop reads `artifact.models`/`artifact.universe` to select cells
+        per model, and `_predict_model` reads `self._recipe.col_slices` for the
+        rebuild guard. Both come off the one loaded artifact.
+
+        No `config`/`device`: predict runs on the numpy backend (CPU always) and
+        the discovery/build path reads no `self.config`. `bids_root` is a caller
+        argument, deliberately not part of X identity; the loaded recipe carries
+        `col_slices` (train-filled) for the rebuild guard.
+        """
+        self._layout = BIDSLayout(bids_root)
+        self._set_recipe_attrs(artifact.recipe)
+        self._artifact = artifact
+
+    @classmethod
+    def load(
+        cls,
+        *,
+        bids_root: str | Path,
+        sub_id: str,
+        desc: str,
+    ) -> "EncodingPredictor":
+        """Load a persisted artifact by `(sub_id, desc)` and wrap it for predict.
+
+        `(sub_id, kind="encoding", desc)` fully determines the file. `sub_id` is the
+        *model* subject (whose trained weights); the source subject is passed to
+        `predict`, and may differ.
+        """
+        layout = BIDSLayout(bids_root)
+        out = layout.path.result(sub=sub_id, kind="encoding", desc=desc)
+        return cls(bids_root=bids_root, artifact=load_artifact(out.path))
+
+    def predict(
+        self,
+        source_sub_id: str,
+        test_on: dict[str, str] | None = None,
+    ) -> list[dict]:
+        """Predict each model's `Y_hat` from a source subject's features.
+
+        Discovers and enriches the features for `source_sub_id` once (the per-model
+        loop reuses one filesystem scan), then for each model in the artifact selects
+        its cells (OOS by default, or `test_on`), subsets the enriched metas, and
+        runs `_predict_model`. Returns one `{row_slices, Y_hat}` per model, in
+        `artifact.models` order — a single-model artifact yields a length-1 list.
+
+        Predict-only: no target Y. `source_sub_id` provides features (X); the model's
+        weights are baked in at load (`EncodingPredictor.__init__`). Comparing
+        `Y_hat` against a target subject's actual BOLD is the `analyze` exercise
+        — it calls
+        `_align_y` on the returned `row_slices` with the target's `bold_metas`.
+
+        Uses full discovery, not the recipe's `bids_filters`: `_select_cells`
+        trusts the stored `train`/`universe` sets and may name cells (`test_on`)
+        outside the train corpus, so the source's available cells must not be
+        pre-narrowed by replaying train-time filters. `_apply_filters` and
+        `_validate_coverage` (a train coverage invariant) are deliberately skipped.
+        """
+        feature_bids = self._discover_features(source_sub_id)
+        bold_metas = self._discover_bold(source_sub_id)
+        feature_bids = self._resolve_cell_keys(source_sub_id, feature_bids, bold_metas)
+        feature_metas = self._enrich_feature_metas(feature_bids, bold_metas)
+        available = {feature_key.cell for feature_key in feature_metas}
+
+        results: list[dict] = []
+        for model in self._artifact.models:
+            cells = _select_cells(available, self._artifact, model, test_on)
+            sub_metas = {
+                feature_key: meta
+                for feature_key, meta in feature_metas.items()
+                if feature_key.cell in cells
+            }
+            results.append(self._predict_model(model, sub_metas))
+        return results
+
+    def _predict_model(
+        self,
+        model: FittedModel,
+        feature_metas: dict[FeatureKey, FeatureMeta],
+    ) -> dict:
+        """Run one model over a pre-selected cell set, returning its `Y_hat` (no Y).
+
+        Consumes pre-discovered, pre-enriched `feature_metas` already subset to the
+        selected cells (the analyze loop calls this K times; re-discovering per call
+        means K+1 filesystem scans). Rebuilds X via the same `_build_x` path as
+        train, asserts `col_slices` matches the recipe (rebuild guard), resets the
+        loaded pipeline's frozen train cell-lengths to this X's geometry, and
+        predicts on the numpy backend.
+
+        Returns `{"row_slices": ..., "Y_hat": ...}` — per-model, no actual Y. The
+        caller does `_align_y(target_bold, row_slices)` for Y to compare against.
+        """
+        from himalaya.backend import set_backend
+
+        data = self._build_x(feature_metas)
+        if data.col_slices != self._recipe.col_slices:
+            raise ValueError(
+                f"col_slices drift: {data.col_slices} != {self._recipe.col_slices}"
+            )
+        set_backend("numpy")
+        cell_lengths = [s.stop - s.start for s in data.row_slices.values()]
+        _reset_cell_lengths(model.pipeline, cell_lengths)
+        Y_hat = model.pipeline.predict(data.X.astype(np.float32))
+        return {"row_slices": data.row_slices, "Y_hat": Y_hat}

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -182,6 +182,19 @@ class TrainingData(XData):
 
 
 @dataclass(frozen=True)
+class Prediction:
+    """One model's predicted BOLD and the row geometry it sits on.
+
+    `row_slices` maps each predicted cell to its contiguous block of rows in
+    `Y_hat` (`_build_x` order). Predict-only: there is no actual Y — `analyze`
+    recovers it from a target subject via `_align_y` on this same geometry.
+    """
+
+    row_slices: dict[CellKey, slice]
+    Y_hat: np.ndarray
+
+
+@dataclass(frozen=True)
 class XRecipe:
     """Everything needed to rebuild X identically on another subject.
 
@@ -1602,20 +1615,17 @@ class EncodingPredictor(_EncodingContext):
         self,
         source_sub_id: str,
         test_on: dict[str, str] | None = None,
-    ) -> list[dict]:
+    ) -> list[Prediction]:
         """Predict each model's `Y_hat` from a source subject's features.
 
         Discovers and enriches the features for `source_sub_id` once (the per-model
         loop reuses one filesystem scan), then for each model in the artifact selects
         its cells (OOS by default, or `test_on`), subsets the enriched metas, and
-        runs `_predict_model`. Returns one `{row_slices, Y_hat}` per model, in
+        runs `_predict_model`. Returns one `Prediction` per model, in
         `artifact.models` order — a single-model artifact yields a length-1 list.
 
-        Predict-only: no target Y. `source_sub_id` provides features (X); the model's
-        weights are baked in at load (`EncodingPredictor.__init__`). Comparing
-        `Y_hat` against a target subject's actual BOLD is the `analyze` exercise
-        — it calls
-        `_align_y` on the returned `row_slices` with the target's `bold_metas`.
+        Predict-only: no target Y. `source_sub_id` provides features (X); the
+        model's weights are baked in at load (`EncodingPredictor.__init__`).
 
         Uses full discovery, not the recipe's `bids_filters`: `_select_cells`
         trusts the stored `train`/`universe` sets and may name cells (`test_on`)
@@ -1629,7 +1639,7 @@ class EncodingPredictor(_EncodingContext):
         feature_metas = self._enrich_feature_metas(feature_bids, bold_metas)
         available = {feature_key.cell for feature_key in feature_metas}
 
-        results: list[dict] = []
+        results: list[Prediction] = []
         for model in self._artifact.models:
             cells = _select_cells(available, self._artifact, model, test_on=test_on)
             sub_metas = {
@@ -1644,7 +1654,7 @@ class EncodingPredictor(_EncodingContext):
         self,
         model: FittedModel,
         feature_metas: dict[FeatureKey, FeatureMeta],
-    ) -> dict:
+    ) -> Prediction:
         """Run one model over a pre-selected cell set, returning its `Y_hat` (no Y).
 
         Consumes pre-discovered, pre-enriched `feature_metas` already subset to the
@@ -1654,8 +1664,8 @@ class EncodingPredictor(_EncodingContext):
         loaded pipeline's frozen train cell-lengths to this X's geometry, and
         predicts on the numpy backend.
 
-        Returns `{"row_slices": ..., "Y_hat": ...}` — per-model, no actual Y. The
-        caller does `_align_y(target_bold, row_slices)` for Y to compare against.
+        Returns a `Prediction` — per-model, no actual Y. The caller does
+        `_align_y(target_bold, prediction.row_slices)` for Y to compare against.
         """
         from himalaya.backend import set_backend
 
@@ -1667,4 +1677,4 @@ class EncodingPredictor(_EncodingContext):
         set_backend("numpy")
         _rebind_cell_lengths(model.pipeline, data.cell_lengths())
         Y_hat = model.pipeline.predict(data.X.astype(np.float32))
-        return {"row_slices": data.row_slices, "Y_hat": Y_hat}
+        return Prediction(row_slices=data.row_slices, Y_hat=Y_hat)

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -128,6 +128,21 @@ class EncodingConfig(BaseModel):
 
 
 @dataclass(frozen=True)
+class FeatureMeta:
+    """One feature cell's TR-grid placement.
+
+    Resolved once by `_enrich_feature_metas` so `_build_x` never reads BOLD.
+    `onset_tr` is currently unconsumed — X rows start at 0 per cell, and `align_y`
+    recomputes its own onset from the target subject's BOLD.
+    """
+
+    bids: BIDSPath
+    n_trs: int
+    onset_tr: int
+    repetition_time: float
+
+
+@dataclass(frozen=True)
 class XData:
     """Assembled feature matrix and its row/column geometry, no target.
 
@@ -279,10 +294,10 @@ def _partition_groups(
 def _select_rows(
     data: TrainingData, cells: set[CellKey]
 ) -> tuple[np.ndarray, np.ndarray, list[CellKey]]:
-    """Slice `data` down to `cells`, preserving `_build_xy` row order.
+    """Slice `data` down to `cells`, preserving `_build_x` row order.
 
     Iterates `data.row_slices` directly — a dict already built in `_sort_key`
-    order by `_build_xy`, so surviving cells keep that order with no re-sort.
+    order by `_build_x`, so surviving cells keep that order with no re-sort.
     The ordered surviving cells are returned so the inner-CV selector and
     `CellDelayer` can recover per-cell row counts from `data.row_slices` in the
     same row order.
@@ -918,7 +933,8 @@ class Encoding:
         feature_bids = self._resolve_cell_keys(sub_id, feature_bids, bold_metas)
         feature_bids, bold_metas = self._apply_filters(sub_id, feature_bids, bold_metas)
         self._validate_coverage(sub_id, feature_bids, bold_metas)
-        data = self._build_xy(feature_bids, bold_metas)
+        feature_metas = self._enrich_feature_metas(feature_bids, bold_metas)
+        data = self._build_training_data(feature_metas, bold_metas)
 
         # himalaya binds the backend at estimator construction, not at fit — set it
         # before building the pipeline or fitting silently falls back to CPU
@@ -964,7 +980,7 @@ class Encoding:
         recipe = replace(self._recipe, col_slices=data.col_slices)
 
         if self._fold is None:
-            # cell order tracks data.row_slices (= _build_xy / _sort_key order)
+            # cell order tracks data.row_slices (= _build_x / _sort_key order)
             ordered_cells = list(data.row_slices)
             pipeline = _fit_model(data.X, data.Y, ordered_cells)
             artifact = EncodingArtifact(
@@ -1030,29 +1046,26 @@ class Encoding:
         enc._recipe = recipe
         return enc
 
-    def predict(
+    def _predict_model(
         self,
         model: EncodingModel,
-        feature_bids: dict[FeatureKey, BIDSPath],
-        bold_metas: dict[BoldKey, BoldMeta],
-        cells: set[CellKey],
+        feature_metas: dict[FeatureKey, FeatureMeta],
     ) -> dict:
-        """Run one model over `cells` of a subject, returning its `Y_hat` (no Y).
+        """Run one model over a pre-selected cell set, returning its `Y_hat` (no Y).
 
-        Consumes pre-discovered `feature_bids`/`bold_metas` (the analyze loop calls
-        predict K times; re-discovering per call means K+1 filesystem scans) and
-        subsets them to `cells`. Rebuilds X via the same `_build_x` path as train,
-        asserts `col_slices` matches the recipe (rebuild guard), resets the loaded
-        pipeline's frozen train cell-lengths to this X's geometry, and predicts on
-        the numpy backend. Discovery already happened upstream.
+        Consumes pre-discovered, pre-enriched `feature_metas` already subset to the
+        selected cells (the analyze loop calls this K times; re-discovering per call
+        means K+1 filesystem scans). Rebuilds X via the same `_build_x` path as
+        train, asserts `col_slices` matches the recipe (rebuild guard), resets the
+        loaded pipeline's frozen train cell-lengths to this X's geometry, and
+        predicts on the numpy backend.
 
         Returns `{"row_slices": ..., "Y_hat": ...}` — per-model, no actual Y. The
         caller does `align_y(target_bold, row_slices)` if it wants Y to compare against.
         """
         from himalaya.backend import set_backend
 
-        sub_feature_bids = {fk: b for fk, b in feature_bids.items() if fk.cell in cells}
-        data = self._build_x(sub_feature_bids, bold_metas)
+        data = self._build_x(feature_metas)
         if data.col_slices != self._recipe.col_slices:
             raise ValueError(
                 f"col_slices drift: {data.col_slices} != {self._recipe.col_slices}"
@@ -1465,25 +1478,74 @@ class Encoding:
                 msg += f" ({len(features_without_bold) - 1} other coverage gaps exist)"
             raise FileNotFoundError(msg)
 
-    def _build_x(
+    def _enrich_feature_metas(
         self,
         feature_bids: dict[FeatureKey, BIDSPath],
         bold_metas: dict[BoldKey, BoldMeta],
-    ) -> XData:
+    ) -> dict[FeatureKey, FeatureMeta]:
+        """Enrich each feature path into a `FeatureMeta` with its TR-grid placement.
+
+        The crossover between feature cells and the BOLD timeline happens here,
+        once: derive `(onset_tr, n_trs)` from the segment TR-slice for segmented
+        runs, or from the run's header `n_trs` for unsegmented runs, and stamp
+        `repetition_time`. `_build_x` then reads placement off the metas and never
+        touches `bold_metas`.
+
+        No BOLD voxel data is read — placement comes from `bold_metas` alone.
+        The header `n_trs` carried by each meta is trusted; `align_y` reconciles
+        it against the actual array.
+        """
+        cells_by_bold_key: dict[BoldKey, set[CellKey]] = {}
+        for feature_key in feature_bids:
+            bold_key = feature_key.cell.to_bold_key()
+            cells_by_bold_key.setdefault(bold_key, set()).add(feature_key.cell)
+
+        placement_by_cell: dict[CellKey, tuple[int, int, float]] = {}
+        for bold_key, cells in cells_by_bold_key.items():
+            bold_meta = bold_metas[bold_key]
+            if not bold_meta.segments:
+                # Unsegmented: the whole run is one cell spanning the full timeline
+                for cell_key in cells:
+                    placement_by_cell[cell_key] = (
+                        0,
+                        bold_meta.n_trs,
+                        bold_meta.repetition_time,
+                    )
+            else:
+                for cell_key in cells:
+                    segment = next(
+                        seg
+                        for seg in bold_meta.segments
+                        if seg.value == cell_key[seg.entity]
+                    )
+                    tr_slice = segment_tr_slice(segment, bold_meta.repetition_time)
+                    placement_by_cell[cell_key] = (
+                        tr_slice.start,  # onset_tr
+                        tr_slice.stop - tr_slice.start,  # n_trs
+                        bold_meta.repetition_time,
+                    )
+
+        feature_metas: dict[FeatureKey, FeatureMeta] = {}
+        for feature_key, bids in feature_bids.items():
+            onset_tr, n_trs, repetition_time = placement_by_cell[feature_key.cell]
+            feature_metas[feature_key] = FeatureMeta(
+                bids=bids,
+                n_trs=n_trs,
+                onset_tr=onset_tr,
+                repetition_time=repetition_time,
+            )
+        return feature_metas
+
+    def _build_x(self, feature_metas: dict[FeatureKey, FeatureMeta]) -> XData:
         """Assemble the X feature matrix and its row/column geometry, no target.
 
-        Takes `bold_metas` because X's per-cell row count and TR come from the
-        BOLD *timeline* (segment TR slices / array length), not its signal — no
-        BOLD data enters X.
+        Reads `n_trs`/`repetition_time` off each cell's `FeatureMeta` — the
+        crossover with the BOLD timeline already happened in `_enrich_feature_metas`,
+        so X no longer touches `bold_metas` and no BOLD data enters X.
 
         Cells are sorted deterministically so row positions are stable across
         runs. Column layout is derived from the first cell and assumed invariant —
-        all cells must yield the same feature dimensionality. Each cell's row count
-        (`n_trs`) comes from its BOLD sidecar: the segment TR slice for segmented
-        runs, or the array length for unsegmented runs. Only unsegmented runs read
-        a BOLD array here (their `n_trs` has no other source); a fully-segmented
-        study reads zero arrays. Segment-coverage against actual array length is
-        deferred to `align_y`, which reads the arrays for Y.
+        all cells must yield the same feature dimensionality.
         """
 
         # None sorts before any value; empty string is a stable tiebreaker for ses/run
@@ -1497,7 +1559,7 @@ class Encoding:
             return (ses is not None, ses or "", task, run is not None, run or "", *rest)
 
         cell_keys = sorted(
-            {feature_key.cell for feature_key in feature_bids}, key=_sort_key
+            {feature_key.cell for feature_key in feature_metas}, key=_sort_key
         )
 
         X_parts: list[np.ndarray] = []
@@ -1508,31 +1570,24 @@ class Encoding:
         col_slices_initialized = False
 
         for cell_key in cell_keys:
-            bold_key = cell_key.to_bold_key()
-            bold_meta = bold_metas[bold_key]
-
-            # n_trs sets this cell's row span; arrays read only when unsegmented
-            if not bold_meta.segments:
-                n_trs = _load_bold_array(bold_meta.bids.path).shape[0]
-            else:
-                segment_value = cell_key[bold_meta.segments[0].entity]
-                seg = next(s for s in bold_meta.segments if s.value == segment_value)
-                tr_slice = segment_tr_slice(seg, bold_meta.repetition_time)
-                n_trs = tr_slice.stop - tr_slice.start
+            # Geometry is per-cell, shared across this cell's feature metas
+            cell_meta = feature_metas[FeatureKey(cell_key, next(iter(self._features)))]
+            n_trs = cell_meta.n_trs
             row_slices[cell_key] = slice(row_offset, row_offset + n_trs)
             row_offset += n_trs
 
             # Construct X for the given cell
             feature_arrays: list[np.ndarray] = []
             for feature_name in self._features:
-                df = read_feature(feature_bids[FeatureKey(cell_key, feature_name)].path)
+                meta = feature_metas[FeatureKey(cell_key, feature_name)]
+                df = read_feature(meta.bids.path)
                 # Drop untimed rows — downsample needs TR alignment
                 df = df.filter(df.get_column("start_time").is_not_null())
                 arr = downsample(
                     stack_array_column(df.get_column("feature")),
                     start_times=df.get_column("start_time").to_numpy(),
                     n_trs=n_trs,
-                    repetition_time=bold_meta.repetition_time,
+                    repetition_time=meta.repetition_time,
                     method=self.downsample,
                 )
                 feature_arrays.append(arr)
@@ -1547,18 +1602,22 @@ class Encoding:
         X = np.concatenate(X_parts, axis=0)
         return XData(X=X, row_slices=row_slices, col_slices=col_slices)
 
-    def _build_xy(
+    def _build_training_data(
         self,
-        feature_bids: dict[FeatureKey, BIDSPath],
+        feature_metas: dict[FeatureKey, FeatureMeta],
         bold_metas: dict[BoldKey, BoldMeta],
     ) -> TrainingData:
-        """Assemble X via `_build_x`, then slice the aligned BOLD target Y onto it.
+        """Bundle X (from `_build_x`) with the aligned BOLD target Y onto its rows.
 
-        Segment slice coverage is validated against actual BOLD array length in
+        The X+Y carrier is train-only — predict stops at X (`_build_x`) and never
+        builds Y. Segment coverage vs. actual BOLD array length is checked in
         `align_y`; a mismatch raises rather than producing a silently truncated Y.
         """
-        data = self._build_x(feature_bids, bold_metas)
-        Y = align_y(bold_metas, data.row_slices)
+        x_data = self._build_x(feature_metas)
+        Y = align_y(bold_metas, x_data.row_slices)
         return TrainingData(
-            X=data.X, row_slices=data.row_slices, col_slices=data.col_slices, Y=Y
+            X=x_data.X,
+            row_slices=x_data.row_slices,
+            col_slices=x_data.col_slices,
+            Y=Y,
         )

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -1262,8 +1262,8 @@ class EncodingTrainer(_EncodingContext):
 
     def __init__(
         self,
-        config: EncodingConfig,
         *,
+        config: EncodingConfig,
         bids_root: str | Path,
         features: list[str],
         tasks: list[str],

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -128,19 +128,30 @@ class EncodingConfig(BaseModel):
 
 
 @dataclass(frozen=True)
-class TrainingData:
-    """Assembled feature and BOLD arrays ready for regression.
+class XData:
+    """Assembled feature matrix and its row/column geometry, no target.
 
-    X and Y share the same row axis: X[row_slices[cell_key]] and
-    Y[row_slices[cell_key]] together give the feature matrix and BOLD
-    response for that cell. col_slices indexes into the column axis of X,
-    mapping each feature name to its contiguous block of columns.
+    `row_slices` maps each cell to its contiguous block of rows in X (in
+    `_sort_key` order); `col_slices` maps each feature name to its contiguous
+    block of columns. This is what predict needs — X alone — and what train
+    extends with Y (see `TrainingData`).
     """
 
     X: np.ndarray
-    Y: np.ndarray
     row_slices: dict[CellKey, slice]
     col_slices: dict[str, slice]
+
+
+@dataclass(frozen=True)
+class TrainingData(XData):
+    """`XData` plus the aligned BOLD target Y, on X's same row axis.
+
+    Subclassing appends `Y` as the last field — construction is kwargs-only at
+    every site, so the positional reorder is inert. Do not switch any
+    `TrainingData(...)` call to positional args without accounting for this.
+    """
+
+    Y: np.ndarray
 
 
 @dataclass(frozen=True)
@@ -399,6 +410,63 @@ def _load_bold_array(path: Path) -> np.ndarray:
         raise ValueError(f"Unsupported image format: {type(img).__name__}")
 
 
+def align_y(
+    bold_metas: dict[BoldKey, BoldMeta], row_slices: dict[CellKey, slice]
+) -> np.ndarray:
+    """Slice each cell's BOLD response onto X's row geometry.
+
+    For each cell in `row_slices`, recompute `onset_tr` from *this*
+    `bold_metas`' TR and segment, then take `arr[onset : onset + n_trs]` where
+    `n_trs` is the row-slice length. Onset is recomputed (not reused from X's
+    build) so a cross-subject Y, whose TR may differ from X's source, slices the
+    correct rows: a segment at 40 s is onset_tr 20 at TR 2.0 but 40 at TR 1.0.
+
+    Raises if a cell's run is absent from `bold_metas`, or if the recomputed
+    `n_trs` disagrees with the row-slice length (TR/duration drift between the
+    subject that built X and this one).
+    """
+    Y_parts: list[np.ndarray] = []
+    arrays: dict[BoldKey, np.ndarray] = {}  # cache per run; segments share a file
+    for cell_key, sl in row_slices.items():
+        bold_key = cell_key.to_bold_key()
+        if bold_key not in bold_metas:
+            raise ValueError(f"No BOLD run for cell {cell_key} (bold_key {bold_key})")
+        bold_meta = bold_metas[bold_key]
+        if bold_key not in arrays:
+            arrays[bold_key] = _load_bold_array(bold_meta.bids.path)
+        bold_data = arrays[bold_key]
+
+        if not bold_meta.segments:
+            onset_tr, n_trs = 0, bold_data.shape[0]
+        else:
+            segment_value = cell_key[bold_meta.segments[0].entity]
+            seg = next(s for s in bold_meta.segments if s.value == segment_value)
+            tr_slice = segment_tr_slice(seg, bold_meta.repetition_time)
+            onset_tr, n_trs = tr_slice.start, tr_slice.stop - tr_slice.start
+
+        # drift guard: fires cross-subject when this run's TR/duration makes the
+        # recomputed span diverge from X's row geometry; inert in same-subject train
+        expected = sl.stop - sl.start
+        if n_trs != expected:
+            raise ValueError(
+                f"Cell {cell_key} spans {expected} row(s) in X but BOLD here "
+                f"yields {n_trs} TR(s) — TR or segment-duration drift between "
+                f"the subject that built X and this one"
+            )
+
+        # bounds check: a too-short array would silently truncate Y (numpy slice)
+        if onset_tr + n_trs > bold_data.shape[0]:
+            raise ValueError(
+                f"Segment for cell {cell_key} extends to TR {onset_tr + n_trs} "
+                f"but BOLD at {bold_meta.bids.path.name} has only "
+                f"{bold_data.shape[0]} TRs"
+            )
+
+        Y_parts.append(bold_data[onset_tr : onset_tr + n_trs])
+
+    return np.concatenate(Y_parts)
+
+
 class CellDelayer(BaseEstimator, TransformerMixin):
     """Stack finite-impulse-response delays of X, one column block per delay.
 
@@ -501,6 +569,112 @@ def _build_pipeline(
     )
 
     return Pipeline([("kernelizer", column_kernelizer), ("model", model)])
+
+
+def _reset_cell_lengths(pipeline: "Pipeline", cell_lengths: list[int]) -> None:
+    """Overwrite each band's `CellDelayer.cell_lengths` to the predict geometry.
+
+    `CellDelayer` froze the *train* subject's per-cell row counts at fit; its
+    `transform` builds FIR boundary masks from them and raises if X's row count
+    disagrees. Predict's cells differ, so the frozen lengths are wrong — reset
+    them before predict. Safe because `cell_lengths` only drives boundary masking
+    and the row-count check (both functions of the current X), never the fitted
+    weights.
+
+    Targets `transformers_` — the fitted transformer clones sklearn made at fit
+    (the same tree `_numpyfy_fitted` walks) — not the unfitted `.transformers`
+    spec. Each entry is `(name, inner_pipeline, col_slice)`; the inner pipeline's
+    `.steps` are `(step_name, estimator)` tuples. `cell_lengths` order must match
+    X's `row_slices` order.
+    """
+    ck = pipeline.named_steps["kernelizer"]
+    for _, transformer, _ in ck.transformers_:
+        for _, step in transformer.steps:
+            if isinstance(step, CellDelayer):
+                step.cell_lengths = cell_lengths
+
+
+def _matches(cell: CellKey, test_on: dict[str, str]) -> bool:
+    """Whether `cell` satisfies every entity constraint in `test_on`.
+
+    Mirrors `_apply_filters._cell_matches`: each `entity -> value` must equal the
+    cell's value for that entity (absent entity never matches). `test_on` is an
+    already-parsed selector; its string grammar is a predict-CLI concern.
+    """
+    return all(cell.get(entity) == value for entity, value in test_on.items())
+
+
+def _assert_same_cell_schema(
+    available: set[CellKey], train_cells: set[CellKey]
+) -> None:
+    """Raise if source and train cells disagree on their entity key set.
+
+    `available - train_cells` is a set op across (possibly) different subjects;
+    `__eq__`/`__hash__` key on the full entity dict, so a differing schema (source
+    missing `cond`, a different descriptive merge) makes the subtraction silently
+    mis-select. The `col_slices` guard checks *columns*; this checks *cells*. Rests
+    on the "same study => same cell schema" invariant from the overview.
+    """
+    schemas = {c.keys() for c in available} | {c.keys() for c in train_cells}
+    if len(schemas) > 1:
+        raise ValueError(
+            f"Cell-schema mismatch between source and train cells: "
+            f"{sorted(sorted(s) for s in schemas)}"
+        )
+
+
+def select_cells(
+    available: set[CellKey],
+    artifact: "EncodingArtifact",
+    model: "EncodingModel",
+    test_on: dict[str, str] | None = None,
+) -> set[CellKey]:
+    """Choose which cells `model` predicts on — OOS by default, or `test_on`.
+
+    Runs upstream of `_build_x`, on the source subject's *full* discovered cells
+    (`available`); recipe filters are not replayed — stored `train`/`universe` are
+    trusted. Three modes (model trained on a subset of cells):
+
+    - `test_on`: explicit override, honored regardless of train membership. Warns
+      (does not reject) on overlap with `train_cells` — predicting on trained-on
+      cells is usually a mistake, occasionally intentional. May name cells outside
+      the train corpus.
+    - K-fold (`universe` set): OOS is `universe - train_cells`, bounded by the
+      universe (cells outside it, e.g. a later run, are excluded).
+    - single model (`universe is None`): OOS is `available - train_cells`,
+      unbounded.
+
+    Raises on an empty selection. For the K-fold branch, also raises if the bounded
+    OOS set is not fully present on the source — its cells are drawn from the train
+    subject's `universe`, so a cell absent here would be silently dropped by the
+    feature-subset filter, yielding fewer predictions with no error. Fail fast.
+    """
+    _assert_same_cell_schema(available, model.train_cells)
+    if test_on:
+        sel = {c for c in available if _matches(c, test_on)}
+        if sel & model.train_cells:
+            logger.warning(
+                "test_on selects {} cell(s) the model was trained on",
+                len(sel & model.train_cells),
+            )
+    elif artifact.universe is not None:
+        sel = artifact.universe - model.train_cells
+    else:
+        sel = available - model.train_cells
+
+    if not sel:
+        if test_on:
+            raise ValueError(f"test_on matched no available cells: {test_on}")
+        raise ValueError("empty out-of-sample set — pass test_on to name cells")
+
+    if artifact.universe is not None:
+        missing = sel - available
+        if missing:
+            raise ValueError(
+                f"bounded OOS cells absent on source subject: "
+                f"{sorted(map(repr, missing))}"
+            )
+    return sel
 
 
 def _numpyfy_fitted(obj: object, _seen: set[int] | None = None) -> None:
@@ -744,7 +918,7 @@ class Encoding:
         feature_bids = self._resolve_cell_keys(sub_id, feature_bids, bold_metas)
         feature_bids, bold_metas = self._apply_filters(sub_id, feature_bids, bold_metas)
         self._validate_coverage(sub_id, feature_bids, bold_metas)
-        data = self._build_xy(sub_id, feature_bids, bold_metas)
+        data = self._build_xy(feature_bids, bold_metas)
 
         # himalaya binds the backend at estimator construction, not at fit — set it
         # before building the pipeline or fitting silently falls back to CPU
@@ -828,6 +1002,66 @@ class Encoding:
         layout = BIDSLayout(bids_root)
         out = layout.path.result(sub=sub, kind="encoding", desc=desc)
         return load_artifact(out.path)
+
+    @classmethod
+    def _from_recipe(cls, recipe: XRecipe, bids_root: str | Path) -> "Encoding":
+        """Rebuild an `Encoding` from a stored recipe to drive predict.
+
+        Predict has no constructor args and runs on a possibly different subject
+        in a different `bids_root`, but discovery/build are instance methods
+        reading `self._features`, `self.bold_space`, etc. Reconstruct exactly those
+        attributes from the recipe. `__new__` bypasses `__init__` validation —
+        recipe values were validated at train, and re-running validation would
+        require dummy `desc`/`fold`/`force` args for no gain.
+
+        No `config`/`device`: predict runs on the numpy backend (CPU always), and
+        the discovery/build path predict uses reads no `self.config`. `bids_root`
+        is a caller argument, deliberately not part of X identity. The loaded
+        recipe carries `col_slices` (train-filled) for the rebuild assert.
+        """
+        enc = cls.__new__(cls)
+        enc._layout = BIDSLayout(bids_root)
+        enc._features = recipe.features
+        enc.tasks = recipe.tasks
+        enc._task_filters = [f"task-{task}" for task in recipe.tasks]
+        enc.bold_space = recipe.bold_space
+        enc._bold_desc = recipe.bold_desc
+        enc.downsample = recipe.downsample
+        enc._recipe = recipe
+        return enc
+
+    def predict(
+        self,
+        model: EncodingModel,
+        feature_bids: dict[FeatureKey, BIDSPath],
+        bold_metas: dict[BoldKey, BoldMeta],
+        cells: set[CellKey],
+    ) -> dict:
+        """Run one model over `cells` of a subject, returning its `Y_hat` (no Y).
+
+        Consumes pre-discovered `feature_bids`/`bold_metas` (the analyze loop calls
+        predict K times; re-discovering per call means K+1 filesystem scans) and
+        subsets them to `cells`. Rebuilds X via the same `_build_x` path as train,
+        asserts `col_slices` matches the recipe (rebuild guard), resets the loaded
+        pipeline's frozen train cell-lengths to this X's geometry, and predicts on
+        the numpy backend. Discovery already happened upstream.
+
+        Returns `{"row_slices": ..., "Y_hat": ...}` — per-model, no actual Y. The
+        caller does `align_y(target_bold, row_slices)` if it wants Y to compare against.
+        """
+        from himalaya.backend import set_backend
+
+        sub_feature_bids = {fk: b for fk, b in feature_bids.items() if fk.cell in cells}
+        data = self._build_x(sub_feature_bids, bold_metas)
+        if data.col_slices != self._recipe.col_slices:
+            raise ValueError(
+                f"col_slices drift: {data.col_slices} != {self._recipe.col_slices}"
+            )
+        set_backend("numpy")
+        cell_lengths = [s.stop - s.start for s in data.row_slices.values()]
+        _reset_cell_lengths(model.pipeline, cell_lengths)
+        Y_hat = model.pipeline.predict(data.X.astype(np.float32))
+        return {"row_slices": data.row_slices, "Y_hat": Y_hat}
 
     def _discover_features(self, sub_id: str) -> dict[FeatureKey, BIDSPath]:
         """Discover and validate feature file paths for a subject.
@@ -1231,46 +1465,26 @@ class Encoding:
                 msg += f" ({len(features_without_bold) - 1} other coverage gaps exist)"
             raise FileNotFoundError(msg)
 
-    def _build_xy(
+    def _build_x(
         self,
-        sub_id: str,
         feature_bids: dict[FeatureKey, BIDSPath],
         bold_metas: dict[BoldKey, BoldMeta],
-    ) -> TrainingData:
-        """Assemble X and Y matrices for regression from feature files and BOLD arrays.
+    ) -> XData:
+        """Assemble the X feature matrix and its row/column geometry, no target.
 
-        Cells are sorted deterministically so row positions in X and Y are stable
-        across runs. Column layout is derived from the first cell and assumed
-        invariant — all cells must yield the same feature dimensionality.
+        Takes `bold_metas` because X's per-cell row count and TR come from the
+        BOLD *timeline* (segment TR slices / array length), not its signal — no
+        BOLD data enters X.
 
-        Segment slice coverage is validated against actual BOLD array length before
-        any data is assembled; a mismatch raises early rather than producing a
-        silently truncated Y.
+        Cells are sorted deterministically so row positions are stable across
+        runs. Column layout is derived from the first cell and assumed invariant —
+        all cells must yield the same feature dimensionality. Each cell's row count
+        (`n_trs`) comes from its BOLD sidecar: the segment TR slice for segmented
+        runs, or the array length for unsegmented runs. Only unsegmented runs read
+        a BOLD array here (their `n_trs` has no other source); a fully-segmented
+        study reads zero arrays. Segment-coverage against actual array length is
+        deferred to `align_y`, which reads the arrays for Y.
         """
-        bold_arrays: dict[BoldKey, np.ndarray] = {
-            key: _load_bold_array(meta.bids.path) for key, meta in bold_metas.items()
-        }
-
-        for bold_key, bold_meta in bold_metas.items():
-            if not bold_meta.segments:
-                continue
-            expected = max(
-                segment_tr_slice(seg, bold_meta.repetition_time).stop
-                for seg in bold_meta.segments
-            )
-            actual = bold_arrays[bold_key].shape[0]
-            if expected > actual:
-                loc = _format_loc(
-                    sub=sub_id,
-                    ses=bold_key.ses,
-                    task=bold_key.task,
-                    run=bold_key.run,
-                    space=self.bold_space,
-                )
-                raise ValueError(
-                    f"events.tsv declares segments extending to TR {expected} "
-                    f"but BOLD at {loc} has only {actual} TRs"
-                )
 
         # None sorts before any value; empty string is a stable tiebreaker for ses/run
         def _sort_key(k: CellKey) -> tuple:
@@ -1287,7 +1501,6 @@ class Encoding:
         )
 
         X_parts: list[np.ndarray] = []
-        Y_parts: list[np.ndarray] = []
         row_slices: dict[CellKey, slice] = {}
         col_slices: dict[str, slice] = {}
         row_offset = 0
@@ -1297,20 +1510,17 @@ class Encoding:
         for cell_key in cell_keys:
             bold_key = cell_key.to_bold_key()
             bold_meta = bold_metas[bold_key]
-            bold_data = bold_arrays[bold_key]
 
-            # Construct Y for the given cell
+            # n_trs sets this cell's row span; arrays read only when unsegmented
             if not bold_meta.segments:
-                onset_tr, n_trs = 0, bold_data.shape[0]
+                n_trs = _load_bold_array(bold_meta.bids.path).shape[0]
             else:
-                segment_entity = bold_meta.segments[0].entity
-                segment_value = cell_key[segment_entity]
+                segment_value = cell_key[bold_meta.segments[0].entity]
                 seg = next(s for s in bold_meta.segments if s.value == segment_value)
                 tr_slice = segment_tr_slice(seg, bold_meta.repetition_time)
-                onset_tr, n_trs = tr_slice.start, tr_slice.stop - tr_slice.start
+                n_trs = tr_slice.stop - tr_slice.start
             row_slices[cell_key] = slice(row_offset, row_offset + n_trs)
             row_offset += n_trs
-            Y_parts.append(bold_data[onset_tr : onset_tr + n_trs])
 
             # Construct X for the given cell
             feature_arrays: list[np.ndarray] = []
@@ -1335,6 +1545,20 @@ class Encoding:
             X_parts.append(np.hstack(feature_arrays))
 
         X = np.concatenate(X_parts, axis=0)
-        Y = np.concatenate(Y_parts, axis=0)
+        return XData(X=X, row_slices=row_slices, col_slices=col_slices)
 
-        return TrainingData(X=X, Y=Y, row_slices=row_slices, col_slices=col_slices)
+    def _build_xy(
+        self,
+        feature_bids: dict[FeatureKey, BIDSPath],
+        bold_metas: dict[BoldKey, BoldMeta],
+    ) -> TrainingData:
+        """Assemble X via `_build_x`, then slice the aligned BOLD target Y onto it.
+
+        Segment slice coverage is validated against actual BOLD array length in
+        `align_y`; a mismatch raises rather than producing a silently truncated Y.
+        """
+        data = self._build_x(feature_bids, bold_metas)
+        Y = align_y(bold_metas, data.row_slices)
+        return TrainingData(
+            X=data.X, row_slices=data.row_slices, col_slices=data.col_slices, Y=Y
+        )

--- a/src/hypline/encoding.py
+++ b/src/hypline/encoding.py
@@ -188,6 +188,10 @@ class XRecipe:
     alphas: list[float]
     col_slices: dict[str, slice] = field(default_factory=dict)
 
+    @property
+    def task_filters(self) -> list[str]:
+        return [f"task-{task}" for task in self.tasks]
+
 
 @dataclass(frozen=True)
 class FittedModel:
@@ -821,33 +825,12 @@ class _EncodingContext:
     populated (validated constructor args vs. a loaded artifact).
     """
 
-    # Attribute contract: subclasses set these (trainer in __init__, predictor via
-    # _set_recipe_attrs). Declared here so the shared methods type-check against the
-    # base. `_layout` is caller-supplied (bids_root); the rest are recipe-derived.
+    # Attribute contract: both subclasses set `self._recipe` (trainer builds it
+    # from validated args, predictor takes `artifact.recipe`), and the shared
+    # discovery/build path reads everything off it. `_layout` is caller-supplied
+    # (bids_root), deliberately not part of X identity.
     _layout: BIDSLayout
-    _features: dict[str, tuple[str, str | None]]
-    tasks: list[str]
-    _task_filters: list[str]
-    bold_space: SurfaceSpace | VolumeSpace
-    _bold_desc: str
-    downsample: FeatureDownsampleMethod
     _recipe: XRecipe
-
-    def _set_recipe_attrs(self, recipe: XRecipe) -> None:
-        """Populate the recipe-derived attrs both roles share.
-
-        These attrs drive the discovery/build path (`_discover_*`, `_build_x`).
-        The trainer fills them inline during validated `__init__`; the predictor
-        calls this from a loaded `artifact.recipe`. `_layout`/`_artifact` are set
-        by the caller — they are not recipe-derived (`bids_root` is a caller arg).
-        """
-        self._features = recipe.features
-        self.tasks = recipe.tasks
-        self._task_filters = [f"task-{task}" for task in recipe.tasks]
-        self.bold_space = recipe.bold_space
-        self._bold_desc = recipe.bold_desc
-        self.downsample = recipe.downsample
-        self._recipe = recipe
 
     def _discover_features(self, sub_id: str) -> dict[FeatureKey, BIDSPath]:
         """Discover and validate feature file paths for a subject.
@@ -866,9 +849,12 @@ class _EncodingContext:
         # Features are dyad-keyed; resolve this subject's dyad via participants.tsv
         dyad_id = self._layout.dyad_of(sub_id)
         feature_bids: dict[FeatureKey, BIDSPath] = {}
-        for feature_name, (kind, desc) in self._features.items():
+        for feature_name, (kind, desc) in self._recipe.features.items():
             feature_files = self._layout.find.features(
-                dyad=dyad_id, kind=kind, desc=desc, bids_filters=self._task_filters
+                dyad=dyad_id,
+                kind=kind,
+                desc=desc,
+                bids_filters=self._recipe.task_filters,
             )
 
             for bids in feature_files:
@@ -925,7 +911,7 @@ class _EncodingContext:
         expected = {
             FeatureKey(cell_key, feature_name)
             for cell_key in {feature_key.cell for feature_key in feature_bids}
-            for feature_name in self._features
+            for feature_name in self._recipe.features
         }
         missing = expected - feature_bids.keys()
         if missing:
@@ -947,16 +933,16 @@ class _EncodingContext:
         to share the same TR, BOLD-level entity invariants, and segment entity (or all
         unsegmented).
         """
-        bold_ext = BOLD_EXTENSIONS[type(self.bold_space)]
+        bold_ext = BOLD_EXTENSIONS[type(self._recipe.bold_space)]
         # Encoding consumes hypline postprocessing outputs, not fmriprep's raw preproc
         bold_files = self._layout.find.hypline(
             sub=sub_id,
             suffix="bold",
             ext=bold_ext,
             bids_filters=[
-                f"space-{self.bold_space}",
-                f"desc-{self._bold_desc}",
-                *self._task_filters,
+                f"space-{self._recipe.bold_space}",
+                f"desc-{self._recipe.bold_desc}",
+                *self._recipe.task_filters,
             ],
         )
 
@@ -1054,7 +1040,7 @@ class _EncodingContext:
                 ses=bold_key.ses,
                 task=bold_key.task,
                 run=bold_key.run,
-                space=self.bold_space,
+                space=self._recipe.bold_space,
             )
 
         cell_keys_by_bold_key: dict[BoldKey, set[CellKey]] = {}
@@ -1229,14 +1215,16 @@ class _EncodingContext:
 
         for cell_key in cell_keys:
             # Geometry is per-cell, shared across this cell's feature metas
-            cell_meta = feature_metas[FeatureKey(cell_key, next(iter(self._features)))]
+            cell_meta = feature_metas[
+                FeatureKey(cell_key, next(iter(self._recipe.features)))
+            ]
             n_trs = cell_meta.n_trs
             row_slices[cell_key] = slice(row_offset, row_offset + n_trs)
             row_offset += n_trs
 
             # Construct X for the given cell
             feature_arrays: list[np.ndarray] = []
-            for feature_name in self._features:
+            for feature_name in self._recipe.features:
                 meta = feature_metas[FeatureKey(cell_key, feature_name)]
                 df = read_feature(meta.bids.path)
                 # Drop untimed rows — downsample needs TR alignment
@@ -1246,11 +1234,11 @@ class _EncodingContext:
                     start_times=df.get_column("start_time").to_numpy(),
                     n_trs=n_trs,
                     repetition_time=meta.repetition_time,
-                    method=self.downsample,
+                    method=self._recipe.downsample,
                 )
                 feature_arrays.append(arr)
             if not col_slices_initialized:
-                for feature_name, arr in zip(self._features, feature_arrays):
+                for feature_name, arr in zip(self._recipe.features, feature_arrays):
                     n_cols = arr.shape[1]
                     col_slices[feature_name] = slice(col_offset, col_offset + n_cols)
                     col_offset += n_cols
@@ -1282,8 +1270,6 @@ class EncodingTrainer(_EncodingContext):
 
         if config.device is Device.CUDA and not torch.cuda.is_available():
             raise RuntimeError("CUDA is requested but not available")
-        self.config = config
-        self._layout = BIDSLayout(bids_root)
 
         if not features:
             raise ValueError("features must be a non-empty list")
@@ -1296,30 +1282,26 @@ class EncodingTrainer(_EncodingContext):
                 " — each kind may appear once"
             )
         # Iteration order fixes X column layout
-        self._features: dict[str, tuple[str, str | None]] = dict(zip(features, parsed))
+        feature_map = dict(zip(features, parsed))
 
         if not tasks:
             raise ValueError("tasks must be a non-empty list")
         if len(tasks) != len(set(tasks)):
             dupes = sorted({t for t in tasks if tasks.count(t) > 1})
             raise ValueError(f"Duplicate entries in tasks: {dupes}")
-        self.tasks = tasks
-        self._task_filters = [f"task-{task}" for task in tasks]
 
-        self.bold_space = parse_bold_space(bold_space)
+        parsed_bold_space = parse_bold_space(bold_space)
 
         if not BIDS_ENTITY_VALUE_RE.match(bold_desc):
             raise ValueError(f"Invalid bold_desc: {bold_desc!r}")
-        self._bold_desc = bold_desc
 
         if downsample not in get_args(FeatureDownsampleMethod):
             raise ValueError(
                 f"downsample must be one of {get_args(FeatureDownsampleMethod)};"
                 f" got {downsample!r}"
             )
-        self.downsample = downsample
 
-        self.bids_filters = normalize_bids_filters(
+        normalized_bids_filters = normalize_bids_filters(
             bids_filters, reserved={"sub", "task", "space", "feat", "desc"}
         )
 
@@ -1331,7 +1313,7 @@ class EncodingTrainer(_EncodingContext):
                 "fold_by and n_folds must be set together or both left unset; "
                 f"got fold_by={fold_by!r}, n_folds={n_folds!r}"
             )
-        self._fold: FoldSpec | None = None
+        fold: FoldSpec | None = None
         if fold_by is not None:
             assert n_folds is not None
             if fold_by in CellKey.EXCLUDE:
@@ -1344,18 +1326,21 @@ class EncodingTrainer(_EncodingContext):
                     f"n_folds must be >= 2 or 'loo'; got {n_folds!r}. A single fold "
                     "is no split — pass n_folds=None for a single model"
                 )
-            self._fold = FoldSpec(by=fold_by, n=n_folds)
+            fold = FoldSpec(by=fold_by, n=n_folds)
 
+        self._config = config
+        self._layout = BIDSLayout(bids_root)
+        self._fold = fold
         # col_slices is filled by train from the assembled TrainingData
         self._recipe = XRecipe(
-            features=self._features,
-            tasks=self.tasks,
-            bold_space=self.bold_space,
-            bold_desc=self._bold_desc,
-            downsample=self.downsample,
-            bids_filters=self.bids_filters,
-            delays=self.config.delays,
-            alphas=self.config.alphas,
+            features=feature_map,
+            tasks=tasks,
+            bold_space=parsed_bold_space,
+            bold_desc=bold_desc,
+            downsample=downsample,
+            bids_filters=normalized_bids_filters,
+            delays=config.delays,
+            alphas=config.alphas,
         )
 
     def train(self, sub_id: str) -> EncodingArtifact:
@@ -1378,7 +1363,7 @@ class EncodingTrainer(_EncodingContext):
         # before building the pipeline or fitting silently falls back to CPU
         from himalaya.backend import set_backend
 
-        set_backend("torch_cuda" if self.config.device is Device.CUDA else "torch")
+        set_backend("torch_cuda" if self._config.device is Device.CUDA else "torch")
 
         # segment entity is invariant across bold_metas (validated in _discover_bold);
         # None when runs are unsegmented
@@ -1407,8 +1392,8 @@ class EncodingTrainer(_EncodingContext):
             pipeline = _build_pipeline(
                 col_slices=data.col_slices,
                 cell_lengths=cell_lengths,
-                delays=self.config.delays,
-                alphas=self.config.alphas,
+                delays=self._config.delays,
+                alphas=self._config.alphas,
                 cv=cv,
             )
             # torch backends want float32; float64 doubles memory and can error on CUDA
@@ -1460,12 +1445,12 @@ class EncodingTrainer(_EncodingContext):
         key absent from both sides raises ValueError (typo diagnostic) before any
         empty-result condition surfaces as a coverage error.
         """
-        if not self.bids_filters:
+        if not self._recipe.bids_filters:
             return feature_bids, bold_metas
 
         # Group filter values by entity for matching later
         allowed_values_by_entity: dict[str, list[str]] = {}
-        for bids_filter in self.bids_filters:
+        for bids_filter in self._recipe.bids_filters:
             entity_key, entity_value = bids_filter.split("-", 1)
             allowed_values_by_entity.setdefault(entity_key, []).append(entity_value)
 
@@ -1533,7 +1518,7 @@ class EncodingTrainer(_EncodingContext):
                 ses=bold_key.ses,
                 task=bold_key.task,
                 run=bold_key.run,
-                space=self.bold_space,
+                space=self._recipe.bold_space,
             )
 
         if not feature_bids:
@@ -1587,19 +1572,20 @@ class EncodingPredictor(_EncodingContext):
     def __init__(self, *, bids_root: str | Path, artifact: EncodingArtifact) -> None:
         """Wrap a loaded artifact to drive predict on a given `bids_root`.
 
-        Reconstructs the discovery/build attrs from `artifact.recipe` (validated
-        at train, so no re-validation here) and stashes the whole `artifact`: the
-        `predict` loop reads `artifact.models`/`artifact.universe` to select cells
-        per model, and `_predict_model` reads `self._recipe.col_slices` for the
-        rebuild guard. Both come off the one loaded artifact.
+        Stores `artifact.recipe` as `self._recipe` (the shared discovery/build path
+        reads everything off it; validated at train, so no re-validation here) and
+        stashes the whole `artifact`: the `predict` loop reads
+        `artifact.models`/`artifact.universe` to select cells per model, and
+        `_predict_model` reads `self._recipe.col_slices` for the rebuild guard. Both
+        come off the one loaded artifact.
 
         No `config`/`device`: predict runs on the numpy backend (CPU always) and
-        the discovery/build path reads no `self.config`. `bids_root` is a caller
+        the discovery/build path reads no `self._config`. `bids_root` is a caller
         argument, deliberately not part of X identity; the loaded recipe carries
         `col_slices` (train-filled) for the rebuild guard.
         """
         self._layout = BIDSLayout(bids_root)
-        self._set_recipe_attrs(artifact.recipe)
+        self._recipe = artifact.recipe
         self._artifact = artifact
 
     @classmethod

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -9,9 +9,9 @@ from hypline.encoding import (
     BoldKey,
     CellDelayer,
     CellKey,
-    Encoding,
     EncodingArtifact,
     EncodingConfig,
+    EncodingTrainer,
     FeatureKey,
     FoldSpec,
     TrainingData,
@@ -20,6 +20,8 @@ from hypline.encoding import (
     _inner_cv,
     _partition_groups,
     _select_rows,
+    load_artifact,
+    write_artifact,
 )
 
 from .conftest import BIDSTree
@@ -40,10 +42,8 @@ def _make_encoding(
     bids_filters: list[str] | None = None,
     fold_by: str | None = None,
     n_folds: int | Literal["loo"] | None = None,
-    desc: str = "v1",
-    force: bool = False,
-) -> Encoding:
-    return Encoding(
+) -> EncodingTrainer:
+    return EncodingTrainer(
         EncodingConfig(),
         bids_root=tree.root,
         features=features,
@@ -53,8 +53,6 @@ def _make_encoding(
         bids_filters=bids_filters,
         fold_by=fold_by,
         n_folds=n_folds,
-        desc=desc,
-        force=force,
     )
 
 
@@ -1663,8 +1661,8 @@ class TestArtifactRoundTrip:
     """Write → load reproduces the recipe, cell set, and predictions exactly."""
 
     def _trained(
-        self, tree: BIDSTree, monkeypatch: pytest.MonkeyPatch, *, force: bool = False
-    ) -> tuple[Encoding, TrainingData]:
+        self, tree: BIDSTree, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[EncodingTrainer, TrainingData]:
         n_rows, n_voxels = 20, 5
         rng = np.random.RandomState(0)
         data = TrainingData(
@@ -1676,7 +1674,7 @@ class TestArtifactRoundTrip:
             },
             col_slices={"phonemic-gpt3": slice(0, 3), "mfcc": slice(3, 7)},
         )
-        enc = _make_encoding(tree, ["phonemic-gpt3", "mfcc"], force=force)
+        enc = _make_encoding(tree, ["phonemic-gpt3", "mfcc"])
         for step in (
             "_discover_features",
             "_discover_bold",
@@ -1696,14 +1694,16 @@ class TestArtifactRoundTrip:
         X = data.X.astype(np.float32)
 
         artifact = enc.train(SUB)
+        out = enc._layout.path.result(sub=SUB, kind="encoding", desc="v1")
+        write_artifact(artifact, out.path)
 
-        # Predictions compare numpy-vs-numpy: train already forced the in-memory
-        # pipeline to the numpy backend during the write, so a plain predict here
-        # is the numpy reference for the reloaded pipeline.
+        # Predictions compare numpy-vs-numpy: write_artifact already forced the
+        # in-memory pipeline to the numpy backend during the dump, so a plain
+        # predict here is the numpy reference for the reloaded pipeline.
         set_backend("numpy")
         ref = np.asarray(artifact.models[0].pipeline.predict(X))
 
-        loaded = Encoding.load(tree.root, sub=SUB, desc="v1")
+        loaded = load_artifact(out.path)
         got = np.asarray(loaded.models[0].pipeline.predict(X))
         np.testing.assert_array_equal(got, ref)
 
@@ -1722,9 +1722,10 @@ class TestArtifactRoundTrip:
         import json
 
         enc, _ = self._trained(tree, monkeypatch)
-        enc.train(SUB)
+        artifact = enc.train(SUB)
 
         out = enc._layout.path.result(sub=SUB, kind="encoding", desc="v1")
+        write_artifact(artifact, out.path)
         sidecar = json.loads(out.path.with_suffix(".json").read_text())
         assert sidecar["recipe"]["tasks"] == [TASK]
         assert sidecar["recipe"]["col_slices"] == {
@@ -1737,28 +1738,6 @@ class TestArtifactRoundTrip:
             frozenset({("task", "a"), ("run", "1")}),
             frozenset({("task", "a"), ("run", "2")}),
         }
-
-    def test_force_governs_overwrite(
-        self, tree: BIDSTree, monkeypatch: pytest.MonkeyPatch
-    ):
-        import os
-
-        enc, _ = self._trained(tree, monkeypatch)
-        enc.train(SUB)
-        out = enc._layout.path.result(sub=SUB, kind="encoding", desc="v1")
-
-        # Backdate the blob so a rewrite is unambiguous (avoids ns-resolution ties)
-        old = 1_000_000_000
-        os.utime(out.path, ns=(old, old))
-
-        # force=False skips: existing file is loaded, not rewritten
-        enc_skip, _ = self._trained(tree, monkeypatch)
-        enc_skip.train(SUB)
-        assert out.path.stat().st_mtime_ns == old
-
-        enc_force, _ = self._trained(tree, monkeypatch, force=True)
-        enc_force.train(SUB)
-        assert out.path.stat().st_mtime_ns != old
 
 
 class TestFoldedTrain:
@@ -1775,7 +1754,7 @@ class TestFoldedTrain:
         fold_by: str,
         n_folds: int | Literal["loo"],
         cells: list[CellKey] | None = None,
-    ) -> tuple[Encoding, TrainingData]:
+    ) -> tuple[EncodingTrainer, TrainingData]:
         cells = cells if cells is not None else self.CELLS
         n_per, n_cols, n_voxels = 5, 7, 3
         rng = np.random.RandomState(0)
@@ -1903,8 +1882,10 @@ class TestFoldedTrain:
 
         enc, data = self._trained(tree, monkeypatch, fold_by="run", n_folds=2)
         artifact = enc.train(SUB)
+        out = enc._layout.path.result(sub=SUB, kind="encoding", desc="v1")
+        write_artifact(artifact, out.path)
 
-        loaded = Encoding.load(tree.root, sub=SUB, desc="v1")
+        loaded = load_artifact(out.path)
         assert len(loaded.models) == len(artifact.models)
         assert loaded.universe == artifact.universe
         assert [m.train_cells for m in loaded.models] == [

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -44,7 +44,7 @@ def _make_encoding(
     n_folds: int | Literal["loo"] | None = None,
 ) -> EncodingTrainer:
     return EncodingTrainer(
-        EncodingConfig(),
+        config=EncodingConfig(),
         bids_root=tree.root,
         features=features,
         tasks=tasks if tasks is not None else [TASK],

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -1409,7 +1409,7 @@ class TestFoldHelpers:
         with pytest.raises(ValueError, match="needs >= 2 groups"):
             _partition_groups(groups, "loo")
 
-    def test_select_rows_preserves_build_xy_order(self):
+    def test_select_rows_preserves_build_x_order(self):
         # row_slices insertion order is _sort_key order; _select_rows must keep it
         data = TrainingData(
             X=np.arange(30).reshape(6, 5).astype(np.float64),
@@ -1570,10 +1570,12 @@ class TestInnerCv:
         assert cv.get_n_splits() == 3
 
 
-class TestBuildXy:
-    """End-to-end `_build_xy`: reads features, downsamples, assembles X."""
+class TestBuildTrainingData:
+    """End-to-end `_build_training_data`: reads features, downsamples, assembles X."""
 
-    def _build_xy(self, tree: BIDSTree, feature_df: pl.DataFrame) -> TrainingData:
+    def _build_training_data(
+        self, tree: BIDSTree, feature_df: pl.DataFrame
+    ) -> TrainingData:
         tree.add_participants({SUB: DYAD})
         tree.add_bold(sub=SUB, task=TASK, space=SPACE, run="1", tr=2.0, desc="denoised")
         tree.add_feature(dyad=DYAD, task=TASK, kind="mfcc", run="1", df=feature_df)
@@ -1583,7 +1585,8 @@ class TestBuildXy:
         feature_bids = enc._resolve_cell_keys(SUB, feature_bids, bold_metas)
         feature_bids, bold_metas = enc._apply_filters(SUB, feature_bids, bold_metas)
         enc._validate_coverage(SUB, feature_bids, bold_metas)
-        return enc._build_xy(feature_bids, bold_metas)
+        feature_metas = enc._enrich_feature_metas(feature_bids, bold_metas)
+        return enc._build_training_data(feature_metas, bold_metas)
 
     def test_untimed_row_dropped_x_matches_all_timed(
         self, tree: BIDSTree, tmp_path_factory: pytest.TempPathFactory
@@ -1606,8 +1609,8 @@ class TestBuildXy:
             schema=schema,
         )
         timed_tree = BIDSTree(tmp_path_factory.mktemp("timed"))
-        x_null = self._build_xy(tree, null_df).X
-        x_timed = self._build_xy(timed_tree, timed_df).X
+        x_null = self._build_training_data(tree, null_df).X
+        x_timed = self._build_training_data(timed_tree, timed_df).X
         np.testing.assert_array_equal(x_null, x_timed)
 
 
@@ -1638,7 +1641,8 @@ class TestTrainWiring:
         ):
             monkeypatch.setattr(enc, step, lambda *a, **k: None)
         monkeypatch.setattr(enc, "_apply_filters", lambda *a, **k: (None, None))
-        monkeypatch.setattr(enc, "_build_xy", lambda *a, **k: data)
+        monkeypatch.setattr(enc, "_enrich_feature_metas", lambda *a, **k: None)
+        monkeypatch.setattr(enc, "_build_training_data", lambda *a, **k: data)
 
         from sklearn.pipeline import Pipeline
 
@@ -1681,7 +1685,8 @@ class TestArtifactRoundTrip:
         ):
             monkeypatch.setattr(enc, step, lambda *a, **k: None)
         monkeypatch.setattr(enc, "_apply_filters", lambda *a, **k: (None, None))
-        monkeypatch.setattr(enc, "_build_xy", lambda *a, **k: data)
+        monkeypatch.setattr(enc, "_enrich_feature_metas", lambda *a, **k: None)
+        monkeypatch.setattr(enc, "_build_training_data", lambda *a, **k: data)
         return enc, data
 
     def test_round_trip(self, tree: BIDSTree, monkeypatch: pytest.MonkeyPatch):
@@ -1794,7 +1799,8 @@ class TestFoldedTrain:
         ):
             monkeypatch.setattr(enc, step, lambda *a, **k: None)
         monkeypatch.setattr(enc, "_apply_filters", lambda *a, **k: (None, None))
-        monkeypatch.setattr(enc, "_build_xy", lambda *a, **k: data)
+        monkeypatch.setattr(enc, "_enrich_feature_metas", lambda *a, **k: None)
+        monkeypatch.setattr(enc, "_build_training_data", lambda *a, **k: data)
         return enc, data
 
     def test_partition_correctness(

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -143,7 +143,7 @@ class TestBuildPipeline:
 class TestEncodingInit:
     def test_valid_config_succeeds(self, tree: BIDSTree):
         enc = _make_encoding(tree, ["mfcc"])
-        assert list(enc._features) == ["mfcc"]
+        assert list(enc._recipe.features) == ["mfcc"]
 
     def test_empty_features_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="non-empty"):
@@ -164,7 +164,7 @@ class TestEncodingInit:
 
     def test_variant_entry_parsed(self, tree: BIDSTree):
         enc = _make_encoding(tree, ["semantic-gpt3"])
-        assert enc._features == {"semantic-gpt3": ("semantic", "gpt3")}
+        assert enc._recipe.features == {"semantic-gpt3": ("semantic", "gpt3")}
 
     def test_desc_reserved_in_filters_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="desc"):
@@ -176,7 +176,7 @@ class TestEncodingInit:
 
     def test_unknown_entity_accepted_at_init(self, tree: BIDSTree):
         enc = _make_encoding(tree, ["mfcc"], bids_filters=["xyz-foo"])
-        assert enc.bids_filters == ["xyz-foo"]
+        assert enc._recipe.bids_filters == ["xyz-foo"]
 
     def test_invalid_bold_space_raises(self, tree: BIDSTree):
         with pytest.raises(ValueError, match="Unsupported BOLD data space"):

--- a/tests/unit/test_encoding.py
+++ b/tests/unit/test_encoding.py
@@ -1583,7 +1583,7 @@ class TestBuildXy:
         feature_bids = enc._resolve_cell_keys(SUB, feature_bids, bold_metas)
         feature_bids, bold_metas = enc._apply_filters(SUB, feature_bids, bold_metas)
         enc._validate_coverage(SUB, feature_bids, bold_metas)
-        return enc._build_xy(SUB, feature_bids, bold_metas)
+        return enc._build_xy(feature_bids, bold_metas)
 
     def test_untimed_row_dropped_x_matches_all_timed(
         self, tree: BIDSTree, tmp_path_factory: pytest.TempPathFactory


### PR DESCRIPTION
## Summary

- Add cross-subject out-of-sample inference: `EncodingPredictor.predict(source_sub_id, test_on=...)` returns one `Prediction` per model, separating the orthogonal *model* / *source* / *target* subjects (the cross-subject join was previously a documented stopgap).
- To share one X-build path between fit and inference, split the monolithic `Encoding` class into `EncodingTrainer` (recipe → fit → artifact) and `EncodingPredictor` (loaded artifact → inference) — train and predict now rebuild X through identical code, with a `col_slices` drift check guarding layout parity.
- Factor X-build apart from Y so X never reads BOLD voxel data: `_enrich_feature_metas` does the one feature↔BOLD-timeline crossover up front, `_build_x` assembles the matrix from metas alone, and only train appends Y (via `_align_y`). New `XData`/`TrainingData`/`Prediction` dataclasses carry the geometry.
- Move artifact persistence out of `train` to the caller via the now-public `write_artifact`; rename `EncodingModel` → `FittedModel` and make `EncodingTrainer.__init__` keyword-only.
- Document the shipped predict path and same-study assumption in the encoding/dyad-keyed/bold notes.